### PR TITLE
adding install-mode flag to operator-sdk subcommand

### DIFF
--- a/cmd/one/command.go
+++ b/cmd/one/command.go
@@ -16,11 +16,12 @@ package one
 
 import (
 	"fmt"
-	"github.com/gobuffalo/envy"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+
+	"github.com/gobuffalo/envy"
 
 	"opcap/pkg"
 	"opcap/pkg/models"
@@ -71,6 +72,8 @@ func NewCmd() *cobra.Command {
 		"Name of Kubernetes Secret to use for pulling registry images")
 	cmd.Flags().StringVar(&flags.ServiceAccount, "service-account", "default",
 		"Name of Kubernetes Service Account to use")
+	cmd.Flags().StringVar(&flags.InstallMode, "install-mode", "AllNamespaces",
+		"Install mode for installing the operator. Accepts following strings as input `MultiNamespace=ns1,ns2 | AllNamespace | OwnNamespace | SingleNamespace=ns1`")
 
 	return cmd
 }
@@ -110,7 +113,7 @@ func run(cmd *cobra.Command, args []string) error {
 	var Bundle models.AuditCapabilities
 
 	log.Info("Deploying operator with operator-sdk...")
-	operatorsdk := exec.Command("operator-sdk", "run", "bundle", flags.FilterBundle, "--pull-secret-name", flags.PullSecretName, "--timeout", "5m")
+	operatorsdk := exec.Command("operator-sdk", "run", "bundle", flags.FilterBundle, "--pull-secret-name", flags.PullSecretName, "--timeout", "5m", "--install-mode", flags.InstallMode)
 	runCommand, err := pkg.RunCommand(operatorsdk)
 
 	if err != nil {

--- a/openshift/capabilities-tool-job.yaml
+++ b/openshift/capabilities-tool-job.yaml
@@ -8,7 +8,7 @@ spec:
       containers:
       - name: opcap
         image: quay.io/opdev/opcap:v0.0.1
-        args: ["one","--container-engine","podman","--output-path","/opt/capabilities-tool","--bundle-image","$(bundle_image)","--bucket-name","$(bucket_name)","--bundle-name","$(bundle_name)"]
+        args: ["one","--container-engine","podman","--output-path","/opt/capabilities-tool","--bundle-image","$(bundle_image)","--bucket-name","$(bucket_name)","--bundle-name","$(bundle_name)","--install-mode","$(installMode)"]
         env:
           - name: bucket_name
             valueFrom:
@@ -40,6 +40,11 @@ spec:
               configMapKeyRef:
                 name: audit-env-var
                 key: bundle_name
+          - name: installMode
+            valueFrom:
+              configMapKeyRef:
+                name: audit-env-var
+                key: installMode
         securityContext:
           privileged: true
         volumeMounts:

--- a/pkg/reports/capabilities/flags.go
+++ b/pkg/reports/capabilities/flags.go
@@ -3,18 +3,19 @@ package capabilities
 // BindFlags define the flags used to generate the bundle report
 type BindFlags struct {
 	//IndexImage      string `json:"image"`
-	BundleName string `json:"bundleName,omitempty"`
 	//Limit           int32  `json:"limit"`
 	//HeadOnly        bool   `json:"headOnly"`
-	Endpoint string `json:"endpoint"`
-	S3Bucket string `json:"s3Bucket"`
 	//Filter          string `json:"filter"`
+	//Namespace       string `json:"namespace"`
+	BundleName      string `json:"bundleName,omitempty"`
+	Endpoint        string `json:"endpoint"`
+	S3Bucket        string `json:"s3Bucket"`
+	InstallMode     string `json:"installMode"`
 	FilterBundle    string `json:"FilterBundle"`
 	OutputPath      string `json:"outputPath"`
 	OutputFormat    string `json:"outputFormat"`
 	ContainerEngine string `json:"containerEngine"`
-	//Namespace       string `json:"namespace"`
-	PullSecretName string `json:"pullSecretName"`
-	ServiceAccount string `json:"serviceAccount"`
-	PackageName    string `json:"packageName,omitempty"`
+	PullSecretName  string `json:"pullSecretName"`
+	ServiceAccount  string `json:"serviceAccount"`
+	PackageName     string `json:"packageName,omitempty"`
 }


### PR DESCRIPTION
This PR will allow users to specify Install modes for operator installation in an OCP cluster.

Signed-off-by: Yash Oza [yoza@gmail.com](mailto:yoza@gmail.com)