### PR TITLE
ADD grpc client package for catalog sources

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -6,23 +6,12 @@ package cmd
 
 import (
 	"fmt"
-	"os"
-
-	"google.golang.org/grpc"
-
-	"github.com/operator-framework/operator-registry/pkg/api"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"context"
-	"io"
-	"time"
 
-	"github.com/operator-framework/operator-registry/pkg/api/grpc_health_v1"
+	"github.com/operator-framework/operator-registry/pkg/client"
 )
 
 // checkCmd represents the check command
@@ -37,7 +26,7 @@ This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Println("check called")
-		c, err := NewClient("172.30.180.138:50051")
+		c, err := client.NewClient("localhost:50051")
 		if err != nil {
 			fmt.Println(err)
 		}
@@ -67,101 +56,4 @@ func init() {
 	// Cobra supports local flags which will only run when this command
 	// is called directly, e.g.:
 	// checkCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
-}
-
-type Client struct {
-	Registry api.RegistryClient
-	Health   grpc_health_v1.HealthClient
-	Conn     *grpc.ClientConn
-}
-
-type Interface interface {
-	GetBundle(ctx context.Context, packageName, channelName, csvName string) (*api.Bundle, error)
-	GetBundleInPackageChannel(ctx context.Context, packageName, channelName string) (*api.Bundle, error)
-	GetReplacementBundleInPackageChannel(ctx context.Context, currentName, packageName, channelName string) (*api.Bundle, error)
-	GetBundleThatProvides(ctx context.Context, group, version, kind string) (*api.Bundle, error)
-	ListBundles(ctx context.Context) (*BundleIterator, error)
-	GetPackage(ctx context.Context, packageName string) (*api.Package, error)
-	HealthCheck(ctx context.Context, reconnectTimeout time.Duration) (bool, error)
-	Close() error
-}
-
-// var _ Interface = &Client{}
-
-type BundleStream interface {
-	Recv() (*api.Bundle, error)
-}
-
-type BundleIterator struct {
-	stream BundleStream
-	error  error
-}
-
-func NewBundleIterator(stream BundleStream) *BundleIterator {
-	return &BundleIterator{stream: stream}
-}
-
-func (it *BundleIterator) Next() *api.Bundle {
-	if it.error != nil {
-		return nil
-	}
-	next, err := it.stream.Recv()
-	if err == io.EOF {
-		return nil
-	}
-	if err != nil {
-		it.error = err
-	}
-	return next
-}
-
-func (it *BundleIterator) Error() error {
-	return it.error
-}
-
-func NewClient(address string) (*Client, error) {
-	conn, err := grpc.Dial(address, grpc.WithInsecure())
-	if err != nil {
-		return nil, err
-	}
-	return NewClientFromConn(conn), nil
-}
-
-func NewClientFromConn(conn *grpc.ClientConn) *Client {
-	return &Client{
-		Registry: api.NewRegistryClient(conn),
-		Health:   grpc_health_v1.NewHealthClient(conn),
-		Conn:     conn,
-	}
-}
-
-func (c *Client) ListBundles(ctx context.Context) (*BundleIterator, error) {
-	stream, err := c.Registry.ListBundles(ctx, &api.ListBundlesRequest{})
-	if err != nil {
-		return nil, err
-	}
-	return NewBundleIterator(stream), nil
-}
-
-// NewClient
-func GetK8sClient() *kubernetes.Clientset {
-	// create k8s client
-	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
-	if err != nil {
-		_ = fmt.Errorf("unable to build config from flags: %v", err)
-	}
-	clientset, _ := kubernetes.NewForConfig(cfg)
-
-	return clientset
-}
-
-func GetTest(c *kubernetes.Clientset) {
-
-	// temporary api commnication test
-	ctx := context.Background()
-	nodes, _ := c.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	for _, n := range nodes.Items {
-		fmt.Print(n.ObjectMeta.Name)
-	}
-
 }

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/h2non/go-is-svg v0.0.0-20160927212452-35e8c4b0612c // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/operator-framework/operator-registry v1.22.0 // indirect
+	github.com/sirupsen/logrus v1.8.1 // indirect
 	google.golang.org/genproto v0.0.0-20210831024726-fe130286e0e2 // indirect
 	google.golang.org/grpc v1.46.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
+github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cobra v1.4.0 h1:y+wJpx64xcgO1V+RcnwW0LEHxTKRi2ZDPSBjWnrg88Q=
@@ -257,6 +259,7 @@ github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stoewer/go-strcase v1.2.0/go.mod h1:IBiWB2sKIp3wVVQ3Y035++gc+knqhUQag1KpM8ahLw8=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
@@ -396,6 +399,7 @@ golang.org/x/sys v0.0.0-20190726091711-fc99dfbffb4e/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20190904154756-749cb33beabd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191001151750-bb3f8db39f24/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191005200804-aed5e4c7ecf9/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191204072324-ce4227a45e2e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191228213918-04cbcbbfeed8/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/internal/operator/operator.go
+++ b/internal/operator/operator.go
@@ -1,5 +1,25 @@
 package operator
 
+import (
+	"fmt"
+	"os"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+// NewClient
+func GetK8sClient() *kubernetes.Clientset {
+	// create k8s client
+	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		_ = fmt.Errorf("unable to build config from flags: %v", err)
+	}
+	clientset, _ := kubernetes.NewForConfig(cfg)
+
+	return clientset
+}
+
 // GetPackageManifests
 
 // CreateNamespace


### PR DESCRIPTION
Deleted all grpc code and imported from operator-registry
Moved k8s client to operator package for now.
Deleted test get node function that is no longer needed.
Changed the grpc endpoint to localhost for development for now.
We need a grpc discovery/port-forward issue to address that in the future.

Signed-off-by: acmenezes <adcmenezes@gmail.com>