### PR TITLE
FIX wait for CSV

### DIFF
--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -98,13 +98,6 @@ func OperatorInstall(s operator.SubscriptionData, c operator.Client, installMode
 	if err = c.WaitForInstallPlan(context.Background(), sub); err != nil {
 		log.Error(err)
 	}
-
-	_, err = c.GetInstalledCSV(context.Background(), namespace)
-	if err != nil {
-		log.Error(err)
-	}
-	// log.Infof("Successfully upgraded to %q", csv.Name)
-
 	// check/approve install plan
 	// TODO: check the name standard for installPlan
 	err = c.InstallPlanApprove(namespace)
@@ -112,43 +105,13 @@ func OperatorInstall(s operator.SubscriptionData, c operator.Client, installMode
 		log.Fatal(err)
 	}
 
-	// check CSV/operator status
-	// 	ticker := time.NewTicker(2 * time.Second)
-	// 	timeout := time.After(1 * time.Minute)
+	csv, err := c.CSVSuceededOnNamespace(namespace)
 
-	// 	time.Sleep(5 * time.Second)
-
-	// loop:
-	// 	for {
-
-	// 		select {
-
-	// 		case <-timeout:
-	// 			fmt.Printf("Operator couldn't be installed in time in namesapce %s", namespace)
-	// 			break loop
-
-	// 		case <-ticker.C:
-	// 			csvPhase, err := c.GetCSVPhase(namespace)
-	// 			if err != nil {
-	// 				if k8serrors.IsNotFound(err) {
-	// 					fmt.Println(err)
-	// 					continue
-	// 				} else {
-	// 					fmt.Println(err)
-	// 					continue
-	// 				}
-	// 			}
-	// 			if csvPhase == operatorv1alpha1.CSVPhaseFailed {
-	// 				fmt.Printf("CSV is failed to install in namespace %s", namespace)
-	// 				break loop
-	// 			}
-	// 			if csvPhase == operatorv1alpha1.CSVPhaseSucceeded {
-	// 				fmt.Printf("CSV is created successfully in namespace %s", namespace)
-	// 				break loop
-	// 			}
-
-	// 		}
-	// 	}
+	if err != nil {
+		fmt.Println(err)
+	} else {
+		fmt.Printf("CSV %s Succeeded", csv.ObjectMeta.Name)
+	}
 
 	// generate and send report
 

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -3,7 +3,6 @@ package operator
 import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -24,10 +23,8 @@ type Client interface {
 	DeleteSubscription(ctx context.Context, name string, namespace string) error
 	GetSubscription(ctx context.Context, name string, namespace string) (*operatorv1alpha1.Subscription, error)
 	InstallPlanApprove(namespace string) error
-	GetCSVPhase(namespace string) (operatorv1alpha1.ClusterServiceVersionPhase, error)
 	WaitForInstallPlan(ctx context.Context, sub *operatorv1alpha1.Subscription) error
-	GetInstalledCSV(ctx context.Context, namespace string) (*operatorv1alpha1.ClusterServiceVersion, error)
-	DoCSVWait(ctx context.Context, key types.NamespacedName) error
+	CSVSuceededOnNamespace(namespace string) (*operatorv1alpha1.ClusterServiceVersion, error)
 }
 
 type operatorClient struct {

--- a/internal/operator/csv.go
+++ b/internal/operator/csv.go
@@ -4,18 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"time"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	log "github.com/sirupsen/logrus"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/wait"
 	runtimeClient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func (c operatorClient) GetCSVPhase(namespace string) (operatorv1alpha1.ClusterServiceVersionPhase, error) {
+func (c operatorClient) CSVSuceededOnNamespace(namespace string) (*operatorv1alpha1.ClusterServiceVersion, error) {
 
 	clusterServiceVersionList := operatorv1alpha1.ClusterServiceVersionList{}
 
@@ -23,91 +18,40 @@ func (c operatorClient) GetCSVPhase(namespace string) (operatorv1alpha1.ClusterS
 		Namespace: namespace,
 	}
 
-	err := c.Client.List(context.Background(), &clusterServiceVersionList, &listOpts)
-	if err != nil {
-		fmt.Println(err)
-		return "", err
-	}
+	deadline := 1 * time.Minute
+	ticker := time.NewTicker(2 * time.Second)
+	timeout := time.After(deadline)
 
-	// TODO: create a custom error for this
-	if len(clusterServiceVersionList.Items) > 1 {
-		return "", fmt.Errorf("more than one CSV found in dedicated namespace %s", fmt.Sprint(len(clusterServiceVersionList.Items)))
-	}
+loop:
+	for {
 
-	if len(clusterServiceVersionList.Items) == 0 {
-		return "", fmt.Errorf("no CSV found in namespace %s", fmt.Sprint(len(clusterServiceVersionList.Items)))
-	}
+		select {
 
-	clusterServiceVersion := operatorv1alpha1.ClusterServiceVersion{}
+		case <-timeout:
+			break loop
 
-	err = c.Client.Get(context.Background(), types.NamespacedName{Name: clusterServiceVersionList.Items[0].ObjectMeta.Name, Namespace: namespace}, &clusterServiceVersion)
-
-	if err != nil {
-		fmt.Println(err)
-		return "", err
-	}
-
-	return clusterServiceVersion.Status.Phase, nil
-}
-
-func (c operatorClient) GetInstalledCSV(ctx context.Context, namespace string) (*operatorv1alpha1.ClusterServiceVersion, error) {
-
-	// BUG(estroz): if namespace is not contained in targetNamespaces,
-	// DoCSVWait will fail because the CSV is not deployed in namespace.
-	nn := types.NamespacedName{
-		Namespace: namespace,
-	}
-	log.Infof("Waiting for ClusterServiceVersion %q to reach 'Succeeded' phase", nn)
-	if err := c.DoCSVWait(ctx, nn); err != nil {
-		return nil, fmt.Errorf("error waiting for CSV to install: %w", err)
-	}
-
-	// TODO: check status of all resources in the desired bundle/package.
-	csv := &operatorv1alpha1.ClusterServiceVersion{}
-	if err := c.Client.Get(ctx, nn, csv); err != nil {
-		return nil, fmt.Errorf("error getting installed CSV: %w", err)
-	}
-	return csv, nil
-}
-
-func (c operatorClient) DoCSVWait(ctx context.Context, key types.NamespacedName) error {
-	var (
-		curPhase operatorv1alpha1.ClusterServiceVersionPhase
-		newPhase operatorv1alpha1.ClusterServiceVersionPhase
-	)
-	once := sync.Once{}
-
-	csv := operatorv1alpha1.ClusterServiceVersion{}
-	csvPhaseSucceeded := func() (bool, error) {
-		err := c.Client.Get(ctx, key, &csv)
-		if err != nil {
-			if apierrors.IsNotFound(err) {
-				once.Do(func() {
-					log.Printf("  Waiting for ClusterServiceVersion %q to appear", key)
-				})
-				return false, nil
+		case <-ticker.C:
+			// list CSVs on namespace
+			err := c.Client.List(context.Background(), &clusterServiceVersionList, &listOpts)
+			if err != nil {
+				fmt.Println(err)
+				return nil, err
 			}
-			return false, err
-		}
-		newPhase = csv.Status.Phase
-		if newPhase != curPhase {
-			curPhase = newPhase
-			log.Printf("  Found ClusterServiceVersion %q phase: %s", key, curPhase)
+
+			if len(clusterServiceVersionList.Items) == 0 {
+
+				continue
+
+			} else if clusterServiceVersionList.Items[0].Status.Phase == operatorv1alpha1.CSVPhaseSucceeded {
+
+				return &clusterServiceVersionList.Items[0], nil
+
+			} else {
+				continue
+			}
 		}
 
-		switch curPhase {
-		case operatorv1alpha1.CSVPhaseFailed:
-			return false, fmt.Errorf("csv failed: reason: %q, message: %q", csv.Status.Reason, csv.Status.Message)
-		case operatorv1alpha1.CSVPhaseSucceeded:
-			return true, nil
-		default:
-			return false, nil
-		}
 	}
 
-	err := wait.PollImmediateUntil(time.Second, csvPhaseSucceeded, ctx.Done())
-	if err != nil && errors.Is(err, context.DeadlineExceeded) {
-		return err
-	}
-	return err
+	return nil, errors.New("Deadline exceeded for CSV on namespace: " + namespace)
 }


### PR DESCRIPTION
the get method requires key with resource name.
That can't be provided therefore replaced with a simple
wait function for the moment.

NOTE: package/channel list still presents duplicates and
namespaces may also need error handling. Got some namespace errors.

Signed-off-by: acmenezes <adcmenezes@gmail.com>