### PR TITLE
error handling on init and client initializations

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ Copyright © 2022 NAME HERE <EMAIL ADDRESS>
 package cmd
 
 import (
+	log "opcap/internal/logger"
 	"opcap/internal/operator"
 	"os"
 
@@ -12,6 +13,7 @@ import (
 )
 
 var osversion string
+var logger = log.Sugar
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -33,6 +35,7 @@ to quickly create a Cobra application.`,
 func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
+		logger.Errorf("Opcap tool execution failed: %s", err)
 		os.Exit(1)
 	}
 }
@@ -40,11 +43,13 @@ func Execute() {
 func init() {
 	opClient, err := operator.NewClient()
 	if err != nil {
-		// TODO: handle error
+		logger.Errorf("Failed to initialize OpenShift client: %s", err)
+		os.Exit(1)
 	}
 
 	osversion, err = opClient.GetOpenShiftVersion()
 	if err != nil {
-		// TODO: handle error
+		logger.Errorf("Failed to connect to OpenShift: %s", err)
+		os.Exit(1)
 	}
 }

--- a/internal/operator/namespace.go
+++ b/internal/operator/namespace.go
@@ -2,22 +2,21 @@ package operator
 
 import (
 	"context"
-	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 // NewClient
 func GetK8sClient() *kubernetes.Clientset {
 	// create k8s client
-	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	kubeconfig, err := ctrl.GetConfig()
 	if err != nil {
 		logger.Errorf("unable to build config from flags: %w", err)
 	}
-	clientset, _ := kubernetes.NewForConfig(cfg)
+	clientset, _ := kubernetes.NewForConfig(kubeconfig)
 
 	return clientset
 }

--- a/internal/operator/version.go
+++ b/internal/operator/version.go
@@ -2,28 +2,9 @@ package operator
 
 import (
 	"context"
-	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/tools/clientcmd"
-	"os"
 )
-
-// getConfigClient returns a OpenShift Config clientset used to get the ClusterVersion resource
-// in order to determine the version of the OpenShift cluster used during opcap run
-func getConfigClient() *configv1.ConfigV1Client {
-	// create openshift config clientset
-	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
-	if err != nil {
-		logger.Errorf("Unable to build config from flags: %s", err)
-	}
-
-	clientset, err := configv1.NewForConfig(cfg)
-	if err != nil {
-		logger.Errorf("Unable to create new OpenShift Config clientset: %s", err)
-	}
-
-	return clientset
-}
 
 // GetOpenShiftVersion uses the OpenShift Config clientset to get a ClusterVersion resource which has the
 // version of an OpenShift cluster
@@ -31,10 +12,7 @@ func (c operatorClient) GetOpenShiftVersion() (string, error) {
 	// version is the OpenShift version of the cluster
 	var version string
 
-	// OpenShift Config client used to talk with the OpenShift API
-	configClient := getConfigClient()
-
-	cversions, err := configClient.ClusterVersions().List(context.TODO(), metav1.ListOptions{})
+	cversions, err := c.KubeClientSet.ClusterVersions().List(context.TODO(), metav1.ListOptions{})
 	if err != nil {
 		version = "0.0.0"
 		return version, err


### PR DESCRIPTION
- Adding a few error messages.
- Replacing `getEnvs` with `ctrl.GetConfig()` which does a more in-depth lookup of KUBECONFIG.
- Adding a k8s ClientSet into the `operatorClient` struct.