### PR TITLE
Merge PackageServerClient into OpCapClient

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -7,8 +7,8 @@ package cmd
 import (
 	"context"
 	"fmt"
+	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	"go/types"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"opcap/internal/operator"
 
 	"opcap/internal/capability"
@@ -31,17 +31,17 @@ var checkCmd = &cobra.Command{
 	// TODO: provide Long description for check command
 	Long: ``,
 	PreRunE: func(cmd *cobra.Command, args []string) error {
-		psc, err := operator.NewPackageServerClient()
+		psc, err := operator.NewOpCapClient()
 		if err != nil {
-			return types.Error{Msg: "Unable to create PackageServer client."}
+			return types.Error{Msg: "Unable to create OpCap client."}
 		}
-
-		pml, err := psc.OperatorsV1().PackageManifests("").List(context.TODO(), metav1.ListOptions{})
+		var packageManifestList pkgserverv1.PackageManifestList
+		err = psc.ListPackageManifests(context.TODO(), &packageManifestList)
 		if err != nil {
 			return types.Error{Msg: "Unable to list PackageManifests."}
 		}
 
-		if len(pml.Items) == 0 {
+		if len(packageManifestList.Items) == 0 {
 			return types.Error{Msg: "No PackageManifests returned from PackageServer."}
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -41,7 +41,7 @@ func Execute() {
 }
 
 func init() {
-	opClient, err := operator.NewClient()
+	opClient, err := operator.NewOpCapClient()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to initialize OpenShift client: ", err)
 		os.Exit(1)

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -25,17 +25,19 @@ type operatorData struct {
 }
 
 func OperatorInstallAllFromCatalog(catalogSource string, catalogSourceNamespace string) error {
-	s, err := operator.Subscriptions(catalogSource, catalogSourceNamespace)
+
+	c, err := operator.NewOpCapClient()
+	if err != nil {
+		logger.Errorf("Error while creating OpCapClient: %w", err)
+		return err
+	}
+
+	s, err := c.GetSubscriptionData(catalogSource, catalogSourceNamespace)
 	if err != nil {
 		logger.Errorf("Error while getting bundles from CatalogSource %s: %w", catalogSource, err)
 		return err
 	}
 
-	c, err := operator.NewClient()
-	if err != nil {
-		logger.Errorf("Error while creating PackageServerClient: %w", err)
-		return err
-	}
 
 	for _, subscription := range s {
 

--- a/internal/operator/namespace.go
+++ b/internal/operator/namespace.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
-// NewClient
+// NewOpCapClient
 func GetK8sClient() *kubernetes.Clientset {
 	// create k8s client
 	cfg, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))


### PR DESCRIPTION
fixes #83

- replaced versioned client set by adding the package server client scheme to opcap client
- added GetSubscriptionData and ListPackageManifests to opcap client
- removed GetSubscription since it was not used
