### PR TITLE
install ALM_Example from CSV to accomplish OperandInstall and OperandCleanUp

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -76,6 +76,7 @@ var checkflags CheckCommandFlags
 func init() {
 
 	var defaultAuditPlan = []string{"OperatorInstall", "OperatorCleanUp"}
+	//for install Operand, add "OperandInstall" to defaultAuditPlan
 
 	rootCmd.AddCommand(checkCmd)
 	flags := checkCmd.Flags()

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -76,7 +76,7 @@ var checkflags CheckCommandFlags
 func init() {
 
 	var defaultAuditPlan = []string{"OperatorInstall", "OperatorCleanUp"}
-	//for install Operand, add "OperandInstall" to defaultAuditPlan
+	//for install Operand, add "OperandInstall", "OperandCleanUp" to defaultAuditPlan
 
 	rootCmd.AddCommand(checkCmd)
 	flags := checkCmd.Flags()

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -76,7 +76,6 @@ var checkflags CheckCommandFlags
 func init() {
 
 	var defaultAuditPlan = []string{"OperatorInstall", "OperatorCleanUp"}
-	//for install Operand, add "OperandInstall", "OperandCleanUp" to defaultAuditPlan
 
 	rootCmd.AddCommand(checkCmd)
 	flags := checkCmd.Flags()

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -13,6 +13,7 @@ import (
 // instance and as part of an auditPlan
 type Audit interface {
 	OperatorInstall() error
+	OperandInstall() error
 	OperatorCleanUp() error
 }
 

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -2,13 +2,13 @@ package capability
 
 import (
 	"context"
-	"encoding/json"
 	"strings"
 
 	"github.com/opdev/opcap/internal/operator"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Audit defines all the methods used to run a full audit Plan against a single operator
@@ -18,6 +18,7 @@ type Audit interface {
 	OperatorInstall() error
 	GetAlmExamples() error
 	OperandInstall() error
+	OperandCleanUp() error
 	OperatorCleanUp() error
 }
 
@@ -90,7 +91,7 @@ func (ca *capAudit) GetAlmExamples() error {
 
 	var almList []map[string]interface{}
 
-	err = json.Unmarshal([]byte(almExamples), &almList)
+	err = yaml.Unmarshal([]byte(almExamples), &almList)
 	if err != nil {
 		return err
 	}

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -1,14 +1,11 @@
 package capability
 
 import (
-	"context"
 	"strings"
 
 	"github.com/opdev/opcap/internal/operator"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // Audit defines all the methods used to run a full audit Plan against a single operator
@@ -16,7 +13,6 @@ import (
 // instance and as part of an auditPlan
 type Audit interface {
 	OperatorInstall() error
-	GetAlmExamples() error
 	OperandInstall() error
 	OperandCleanUp() error
 	OperatorCleanUp() error
@@ -67,38 +63,6 @@ func newOperatorGroupData(name string, targetNamespaces []string) operator.Opera
 		Name:             name,
 		TargetNamespaces: targetNamespaces,
 	}
-}
-
-// function to get all the ALMExamples present in a given CSV
-func (ca *capAudit) GetAlmExamples() error {
-	ctx := context.Background()
-
-	olmClientset, err := operator.NewOlmClientset()
-	if err != nil {
-		return err
-	}
-
-	opts := v1.ListOptions{}
-
-	// gets the list of CSVs present in a particular namespace
-	CSVList, err := olmClientset.OperatorsV1alpha1().ClusterServiceVersions(ca.namespace).List(ctx, opts)
-	if err != nil {
-		return err
-	}
-
-	// map of string interface which consist of ALM examples from the CSVList
-	almExamples := CSVList.Items[0].ObjectMeta.Annotations["alm-examples"]
-
-	var almList []map[string]interface{}
-
-	err = yaml.Unmarshal([]byte(almExamples), &almList)
-	if err != nil {
-		return err
-	}
-
-	ca.customResources = almList
-
-	return nil
 }
 
 func getTargetNamespaces(s operator.SubscriptionData, namespace string) []string {

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -56,7 +56,7 @@ func (ca *capAudit) OperandCleanUp() error {
 			// delete the resource using the dynamic client
 			err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
 			if err != nil {
-				fmt.Printf("failed operandCleanUp: %s package: %s error: %s", Resource, ca.subscription.Package, err.Error())
+				fmt.Printf("failed operandCleanUp: %s package: %s error: %s\n", Resource, ca.subscription.Package, err.Error())
 				return err
 			}
 		}

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -12,10 +12,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+// OperandCleanup removes the operand from the OCP cluster in the ca.namespace
 func (ca *capAudit) OperandCleanUp() error {
 	logger.Debugw("cleaningUp operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
-
-	ca.GetAlmExamples()
 
 	obj := &unstructured.Unstructured{Object: ca.customResources[0]}
 
@@ -33,12 +32,14 @@ func (ca *capAudit) OperandCleanUp() error {
 
 	var Resource string
 
+	// iterate over the CRD list to find the CRD for the resource we are trying to delete
 	for _, crd := range crdList.Items {
 		if crd.Spec.Group == obj.GroupVersionKind().Group && crd.Spec.Names.Kind == obj.GroupVersionKind().Kind {
 			Resource = crd.Spec.Names.Plural
 		}
 	}
 
+	// register the GVR to be deleted
 	gvr := schema.GroupVersionResource{
 		Group:    obj.GroupVersionKind().Group,
 		Version:  obj.GroupVersionKind().Version,
@@ -48,6 +49,7 @@ func (ca *capAudit) OperandCleanUp() error {
 	// extract name from CustomResource object and delete it
 	name := obj.Object["metadata"].(map[string]interface{})["name"].(string)
 
+	// delete the resource using the dynamic client
 	err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
 	if err != nil {
 		logger.Infow("failed", "operandCleanUp", Resource, "package", ca.subscription.Package, "error", err.Error())

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -1,0 +1,57 @@
+package capability
+
+import (
+	"context"
+	"log"
+	"opcap/internal/operator"
+
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func (ca *capAudit) OperandCleanUp() error {
+	logger.Debugw("cleaningUp operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
+
+	ca.GetAlmExamples()
+
+	obj := &unstructured.Unstructured{Object: ca.customResources[0]}
+
+	// using dynamic client to create Unstructured objests in k8s
+	client, err := operator.NewDynamicClient()
+	if err != nil {
+		log.Println(err)
+	}
+
+	var crdList apiextensionsv1.CustomResourceDefinitionList
+	err = ca.client.ListCRDs(context.TODO(), &crdList)
+	if err != nil {
+		logger.Error(err.Error())
+	}
+
+	var Resource string
+
+	for _, crd := range crdList.Items {
+		if crd.Spec.Group == obj.GroupVersionKind().Group && crd.Spec.Names.Kind == obj.GroupVersionKind().Kind {
+			Resource = crd.Spec.Names.Plural
+		}
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    obj.GroupVersionKind().Group,
+		Version:  obj.GroupVersionKind().Version,
+		Resource: Resource,
+	}
+
+	// extract name from CustomResource object and delete it
+	name := obj.Object["metadata"].(map[string]interface{})["name"].(string)
+
+	err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
+	if err != nil {
+		logger.Infow("failed", "operandCleanUp", Resource, "package", ca.subscription.Package, "error", err.Error())
+	}
+
+	return nil
+}

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -2,8 +2,10 @@ package capability
 
 import (
 	"context"
+	"fmt"
 	"log"
-	"opcap/internal/operator"
+
+	"github.com/opdev/opcap/internal/operator"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -52,7 +54,7 @@ func (ca *capAudit) OperandCleanUp() error {
 	// delete the resource using the dynamic client
 	err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
 	if err != nil {
-		logger.Infow("failed", "operandCleanUp", Resource, "package", ca.subscription.Package, "error", err.Error())
+		fmt.Printf("failed operandCleanUp: %s package: %s error: %s", Resource, ca.subscription.Package, err.Error())
 	}
 
 	return nil

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -3,7 +3,6 @@ package capability
 import (
 	"context"
 	"fmt"
-	"log"
 
 	"github.com/opdev/opcap/internal/operator"
 
@@ -24,13 +23,13 @@ func (ca *capAudit) OperandCleanUp() error {
 		// using dynamic client to create Unstructured objests in k8s
 		client, err := operator.NewDynamicClient()
 		if err != nil {
-			log.Println(err)
+			return err
 		}
 
 		var crdList apiextensionsv1.CustomResourceDefinitionList
 		err = ca.client.ListCRDs(context.TODO(), &crdList)
 		if err != nil {
-			logger.Error(err.Error())
+			return err
 		}
 
 		var Resource string
@@ -42,7 +41,6 @@ func (ca *capAudit) OperandCleanUp() error {
 			}
 		}
 
-		// register the GVR to be deleted
 		gvr := schema.GroupVersionResource{
 			Group:    obj.GroupVersionKind().Group,
 			Version:  obj.GroupVersionKind().Version,
@@ -59,6 +57,7 @@ func (ca *capAudit) OperandCleanUp() error {
 			err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
 			if err != nil {
 				fmt.Printf("failed operandCleanUp: %s package: %s error: %s", Resource, ca.subscription.Package, err.Error())
+				return err
 			}
 		}
 	}

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -89,16 +89,16 @@ func (ca *capAudit) OperandInstall() error {
 			// create the resource using the dynamic client and log the error if it occurs in stdout.json
 			_, err = client.Resource(gvr).Namespace(ca.namespace).Create(context.TODO(), obj, v1.CreateOptions{})
 			if err != nil {
-				fmt.Printf("operand failed to create: %s package: %s error: %s", Resource, ca.subscription.Package, err)
+				fmt.Printf("operand failed to create: %s package: %s error: %s\n", Resource, ca.subscription.Package, err)
 				return err
 			} else {
 				fmt.Printf("operand succeeded: %s package: %s", Resource, ca.subscription.Package)
 			}
 		} else {
-			fmt.Printf("exiting OperandInstall since CSV has failed")
+			fmt.Printf("exiting OperandInstall since CSV has failed\n")
 		}
 	} else {
-		fmt.Printf("exiting OperandInstall since no ALM_Examples found in CSV")
+		fmt.Printf("exiting OperandInstall since no ALM_Examples found in CSV\n")
 	}
 
 	return nil

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -2,8 +2,10 @@ package capability
 
 import (
 	"context"
+	"fmt"
 	"log"
-	"opcap/internal/operator"
+
+	"github.com/opdev/opcap/internal/operator"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
@@ -85,9 +87,9 @@ func (ca *capAudit) OperandInstall() error {
 	// create the resource using the dynamic client and log the error if it occurs in stdout.json
 	_, err = client.Resource(gvr).Namespace(ca.namespace).Create(context.TODO(), obj, v1.CreateOptions{})
 	if err != nil {
-		logger.Infow("failed", "operand", Resource, "package", ca.subscription.Package, "error", err.Error())
+		fmt.Printf("operand failed to create: %s package: %s error: %s", Resource, ca.subscription.Package, err)
 	} else {
-		logger.Infow("succeeded", "operand", Resource, "package", ca.subscription.Package)
+		fmt.Printf("operand succeeded: %s package: %s", Resource, ca.subscription.Package)
 	}
 
 	return nil

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -1,0 +1,68 @@
+package capability
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+	"opcap/internal/operator"
+	"os"
+	"strings"
+
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+func (ca *capAudit) OperandInstall() error {
+	logger.Debugw("installing operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
+
+	var csv *operatorv1alpha1.ClusterServiceVersion
+	ctx := context.Background()
+
+	olmClientset, err := operator.NewOlmClientset()
+	if err != nil {
+		return err
+	}
+
+	opts := v1.ListOptions{}
+	var watch watch.Interface
+	var ok bool
+
+	watch, err = olmClientset.OperatorsV1alpha1().ClusterServiceVersions(ca.namespace).Watch(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	for event := range watch.ResultChan() {
+		csv, ok = event.Object.(*operatorv1alpha1.ClusterServiceVersion)
+		if !ok {
+			return fmt.Errorf("received unexpected object type from watch: object-type %T", event.Object)
+		}
+		alm := csv.ObjectMeta.Annotations["alm-examples"]
+		var almList []map[string]interface{}
+		json.Unmarshal([]byte(alm), &almList)
+		obj := &unstructured.Unstructured{Object: almList[0]}
+
+		config, _ := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+		client, _ := dynamic.NewForConfig(config)
+
+		groupVersion := strings.Split(obj.GetAPIVersion(), "/")
+		gvr := schema.GroupVersionResource{
+			Group:    groupVersion[0],
+			Version:  groupVersion[1],
+			Resource: obj.GetKind(),
+		}
+
+		_, err := client.Resource(gvr).Namespace(ca.namespace).Create(context.TODO(), obj, v1.CreateOptions{})
+		if err != nil {
+			log.Println(err)
+		}
+
+	}
+	return nil
+}

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -2,67 +2,40 @@ package capability
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
 	"log"
 	"opcap/internal/operator"
-	"os"
 	"strings"
 
-	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/watch"
-	"k8s.io/client-go/dynamic"
-	"k8s.io/client-go/tools/clientcmd"
 )
 
 func (ca *capAudit) OperandInstall() error {
 	logger.Debugw("installing operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
 
-	var csv *operatorv1alpha1.ClusterServiceVersion
-	ctx := context.Background()
+	ca.GetAlmExamples()
 
-	olmClientset, err := operator.NewOlmClientset()
+	// TODO: we need a stratergy to select which CR to select from ALMExamplesList
+	obj := &unstructured.Unstructured{Object: ca.customResources[0]}
+
+	// using dynamic client to create Unstructured objests in k8s
+	client, err := operator.NewDynamicClient()
 	if err != nil {
-		return err
+		log.Println(err)
 	}
 
-	opts := v1.ListOptions{}
-	var watch watch.Interface
-	var ok bool
+	groupVersion := strings.Split(obj.GetAPIVersion(), "/")
+	gvr := schema.GroupVersionResource{
+		Group:    groupVersion[0],
+		Version:  groupVersion[1],
+		Resource: obj.GetKind(),
+	}
 
-	watch, err = olmClientset.OperatorsV1alpha1().ClusterServiceVersions(ca.namespace).Watch(ctx, opts)
+	_, err = client.Resource(gvr).Namespace(ca.namespace).Create(context.TODO(), obj, v1.CreateOptions{})
 	if err != nil {
-		return err
+		log.Println(err)
 	}
 
-	for event := range watch.ResultChan() {
-		csv, ok = event.Object.(*operatorv1alpha1.ClusterServiceVersion)
-		if !ok {
-			return fmt.Errorf("received unexpected object type from watch: object-type %T", event.Object)
-		}
-		alm := csv.ObjectMeta.Annotations["alm-examples"]
-		var almList []map[string]interface{}
-		json.Unmarshal([]byte(alm), &almList)
-		obj := &unstructured.Unstructured{Object: almList[0]}
-
-		config, _ := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
-		client, _ := dynamic.NewForConfig(config)
-
-		groupVersion := strings.Split(obj.GetAPIVersion(), "/")
-		gvr := schema.GroupVersionResource{
-			Group:    groupVersion[0],
-			Version:  groupVersion[1],
-			Resource: obj.GetKind(),
-		}
-
-		_, err := client.Resource(gvr).Namespace(ca.namespace).Create(context.TODO(), obj, v1.CreateOptions{})
-		if err != nil {
-			log.Println(err)
-		}
-
-	}
 	return nil
 }

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -97,6 +97,8 @@ func (ca *capAudit) OperandInstall() error {
 		} else {
 			fmt.Printf("exiting OperandInstall since CSV has failed")
 		}
+	} else {
+		fmt.Printf("exiting OperandInstall since no ALM_Examples found in CSV")
 	}
 
 	return nil

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -3,7 +3,6 @@ package capability
 import (
 	"context"
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/opdev/opcap/internal/operator"
@@ -59,7 +58,7 @@ func (ca *capAudit) OperandInstall() error {
 		// using dynamic client to create Unstructured objests in k8s
 		client, err := operator.NewDynamicClient()
 		if err != nil {
-			log.Println(err)
+			return err
 		}
 
 		// set the namespace of CR to the namespace of the subscription
@@ -68,7 +67,7 @@ func (ca *capAudit) OperandInstall() error {
 		var crdList apiextensionsv1.CustomResourceDefinitionList
 		err = ca.client.ListCRDs(context.TODO(), &crdList)
 		if err != nil {
-			logger.Error(err.Error())
+			return err
 		}
 
 		var Resource string
@@ -91,6 +90,7 @@ func (ca *capAudit) OperandInstall() error {
 			_, err = client.Resource(gvr).Namespace(ca.namespace).Create(context.TODO(), obj, v1.CreateOptions{})
 			if err != nil {
 				fmt.Printf("operand failed to create: %s package: %s error: %s", Resource, ca.subscription.Package, err)
+				return err
 			} else {
 				fmt.Printf("operand succeeded: %s package: %s", Resource, ca.subscription.Package)
 			}

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -10,12 +10,45 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
+func (ca *capAudit) getAlmExamples() error {
+	ctx := context.Background()
+
+	olmClientset, err := operator.NewOlmClientset()
+	if err != nil {
+		return err
+	}
+
+	opts := v1.ListOptions{}
+
+	// gets the list of CSVs present in a particular namespace
+	CSVList, err := olmClientset.OperatorsV1alpha1().ClusterServiceVersions(ca.namespace).List(ctx, opts)
+	if err != nil {
+		return err
+	}
+
+	// map of string interface which consist of ALM examples from the CSVList
+	almExamples := CSVList.Items[0].ObjectMeta.Annotations["alm-examples"]
+
+	var almList []map[string]interface{}
+
+	err = yaml.Unmarshal([]byte(almExamples), &almList)
+	if err != nil {
+		return err
+	}
+
+	ca.customResources = almList
+
+	return nil
+}
+
+// OperandInstall installs the operand from the ALMExamples in the ca.namespace
 func (ca *capAudit) OperandInstall() error {
 	logger.Debugw("installing operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
 
-	ca.GetAlmExamples()
+	ca.getAlmExamples()
 
 	// TODO: we need a stratergy to select which CR to select from ALMExamplesList
 	obj := &unstructured.Unstructured{Object: ca.customResources[0]}
@@ -26,6 +59,7 @@ func (ca *capAudit) OperandInstall() error {
 		log.Println(err)
 	}
 
+	// set the namespace of CR to the namespace of the subscription
 	obj.SetNamespace(ca.namespace)
 
 	var crdList apiextensionsv1.CustomResourceDefinitionList
@@ -48,6 +82,7 @@ func (ca *capAudit) OperandInstall() error {
 		Resource: Resource,
 	}
 
+	// create the resource using the dynamic client and log the error if it occurs in stdout.json
 	_, err = client.Resource(gvr).Namespace(ca.namespace).Create(context.TODO(), obj, v1.CreateOptions{})
 	if err != nil {
 		logger.Infow("failed", "operand", Resource, "package", ca.subscription.Package, "error", err.Error())

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -8,6 +8,8 @@ import (
 
 	log "github.com/opdev/opcap/internal/logger"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -30,8 +32,9 @@ type Client interface {
 	DeleteSubscription(ctx context.Context, name string, namespace string) error
 	WaitForCsvOnNamespace(namespace string) (string, error)
 	GetOpenShiftVersion() (string, error)
-	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, filter []string) error
-	GetSubscriptionData(source string, namespace string, filter []string) ([]SubscriptionData, error)
+	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList) error
+	GetSubscriptionData(source string, namespace string) ([]SubscriptionData, error)
+	ListCRDs(ctx context.Context, list *apiextensionsv1.CustomResourceDefinitionList) error
 }
 
 type operatorClient struct {
@@ -50,6 +53,10 @@ func NewOpCapClient() (Client, error) {
 	}
 
 	if err := pkgserverv1.AddToScheme(scheme); err != nil {
+		return nil, err
+	}
+
+	if err := apiextensionsv1.AddToScheme(scheme); err != nil {
 		return nil, err
 	}
 

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -17,6 +17,7 @@ import (
 	olmclient "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned"
 	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 
+	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -82,4 +83,17 @@ func NewOlmClientset() (*olmclient.Clientset, error) {
 	}
 
 	return olmClientset, nil
+}
+
+// NewDynamicClient creates a new dynamic client or returns an error.
+func NewDynamicClient() (dynamic.Interface, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", os.Getenv("KUBECONFIG"))
+	if err != nil {
+		return nil, err
+	}
+	client, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return client, nil
 }

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -32,8 +32,8 @@ type Client interface {
 	DeleteSubscription(ctx context.Context, name string, namespace string) error
 	WaitForCsvOnNamespace(namespace string) (string, error)
 	GetOpenShiftVersion() (string, error)
-	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList) error
-	GetSubscriptionData(source string, namespace string) ([]SubscriptionData, error)
+	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, filter []string) error
+	GetSubscriptionData(source string, namespace string, filter []string) ([]SubscriptionData, error)
 	ListCRDs(ctx context.Context, list *apiextensionsv1.CustomResourceDefinitionList) error
 }
 

--- a/internal/operator/subscription.go
+++ b/internal/operator/subscription.go
@@ -7,6 +7,7 @@ import (
 	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -108,4 +109,9 @@ func (c operatorClient) ListPackageManifests(ctx context.Context, list *pkgserve
 	}
 
 	return nil
+}
+
+// ListCRDs returns the list of CRDs present in the cluster
+func (c operatorClient) ListCRDs(ctx context.Context, list *apiextensionsv1.CustomResourceDefinitionList) error {
+	return c.Client.List(ctx, list)
 }


### PR DESCRIPTION
In order to check the capability of an Operator, we should be able to install the Operand presented as ALM_Example in the CSV.

- creating a CR from the ALM example if CSV has any ALM_Examples
- Using Dynamic client to register the GVR
- Create the CR in the same namespace as the operator Install
- Checks if the CR was created without any errors, else logs those errors
- Once the Operand is Installed, we delete the CR so that the Namespace is not stuck on terminating because of K8s finalizers
- Checks if operand was created first, only then proceed with Operand CleanUp
- Also implementing the ListCRDs function to get the Resource type to register the GVR.

Resolves #1  

Signed-off-by: Yash Oza <yoyashoza@gmail.com>