### PR TITLE
Add filter flag

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -32,7 +32,7 @@ var checkCmd = &cobra.Command{
 			return types.Error{Msg: "Unable to create OpCap client."}
 		}
 		var packageManifestList pkgserverv1.PackageManifestList
-		err = psc.ListPackageManifests(context.TODO(), &packageManifestList)
+		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.FilterPackages)
 		if err != nil {
 			return types.Error{Msg: "Unable to list PackageManifests."}
 		}
@@ -54,7 +54,7 @@ var checkCmd = &cobra.Command{
 		fmt.Println("check called")
 
 		// Build auditor by catalog
-		auditor, err := capability.BuildAuditorByCatalog(checkflags.CatalogSource, checkflags.CatalogSourceNamespace, checkflags.AuditPlan)
+		auditor, err := capability.BuildAuditorByCatalog(checkflags.CatalogSource, checkflags.CatalogSourceNamespace, checkflags.AuditPlan, checkflags.FilterPackages)
 		if err != nil {
 			logger.Sugar.Fatal("Unable to build auditor")
 		}
@@ -68,6 +68,7 @@ type CheckCommandFlags struct {
 	CatalogSource          string   `json:"catalogsource"`
 	CatalogSourceNamespace string   `json:"catalogsourcenamespace"`
 	ListPackages           bool     `json:"listPackages"`
+	FilterPackages         []string `json:"filterPackages"`
 }
 
 var checkflags CheckCommandFlags
@@ -85,4 +86,5 @@ func init() {
 		"")
 	flags.StringArrayVar(&checkflags.AuditPlan, "auditplan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
 	flags.BoolVar(&checkflags.ListPackages, "list-packages", false, "list packages in the catalog")
+	flags.StringSliceVar(&checkflags.FilterPackages, "filter-packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
 }

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -21,10 +21,10 @@ type capAuditor struct {
 }
 
 // BuildAuditorByCatalog creates a new Auditor with workqueue based on a selected catalog
-func BuildAuditorByCatalog(catalogSource string, catalogSourceNamespace string, auditPlan []string) (capAuditor, error) {
+func BuildAuditorByCatalog(catalogSource string, catalogSourceNamespace string, auditPlan []string, filter []string) (capAuditor, error) {
 
 	var auditor capAuditor
-	err := auditor.BuildWorkQueueByCatalog(catalogSource, catalogSourceNamespace, auditPlan)
+	err := auditor.BuildWorkQueueByCatalog(catalogSource, catalogSourceNamespace, auditPlan, filter)
 	if err != nil {
 		logger.Fatalf("Unable to build workqueue err := %s", err.Error())
 	}
@@ -32,7 +32,7 @@ func BuildAuditorByCatalog(catalogSource string, catalogSourceNamespace string, 
 }
 
 // BuildWorkQueueByCatalog fills in the auditor workqueue with all package information found in a specific catalog
-func (capAuditor *capAuditor) BuildWorkQueueByCatalog(catalogSource string, catalogSourceNamespace string, auditPlan []string) error {
+func (capAuditor *capAuditor) BuildWorkQueueByCatalog(catalogSource string, catalogSourceNamespace string, auditPlan []string, filter []string) error {
 
 	c, err := operator.NewOpCapClient()
 	if err != nil {
@@ -42,7 +42,7 @@ func (capAuditor *capAuditor) BuildWorkQueueByCatalog(catalogSource string, cata
 	}
 
 	// Getting subscription data form the package manifests available in the selected catalog
-	s, err := c.GetSubscriptionData(catalogSource, catalogSourceNamespace)
+	s, err := c.GetSubscriptionData(catalogSource, catalogSourceNamespace, filter)
 	if err != nil {
 		logger.Errorf("Error while getting bundles from CatalogSource %s: %w", catalogSource, err)
 		return err

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -30,8 +30,8 @@ type Client interface {
 	ApproveInstallPlan(ctx context.Context, sub *operatorv1alpha1.Subscription) error
 	WaitForCsvOnNamespace(namespace string) (string, error)
 	GetOpenShiftVersion() (string, error)
-	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList) error
-	GetSubscriptionData(source string, namespace string) ([]SubscriptionData, error)
+	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, filter []string) error
+	GetSubscriptionData(source string, namespace string, filter []string) ([]SubscriptionData, error)
 }
 
 type operatorClient struct {


### PR DESCRIPTION
Allow testing a single operator. You will need to know the specific package name to pass to filter. --list-packages can be used to obtain the package name.
Resolves #103

Signed-off-by: Melvin Hillsman <mrhillsman@gmail.com>