### PR TITLE
Add version command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ GO_VERSION:=$(shell go version | cut -f 3 -d " ")
 BUILD_TIME:=$(shell date)
 GIT_USER:=$(shell git log | grep -A2 $$(git rev-list -1 HEAD) | grep Author)
 GIT_COMMIT=$(shell git rev-parse HEAD)
-OPCAP_VERSION?="0.0.0"
+OPCAP_VERSION?="0.0.1"
 
 PLATFORMS=linux
 ARCHITECTURES=amd64 arm64 ppc64le s390x

--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,11 @@ ARCHITECTURES=amd64 arm64 ppc64le s390x
 
 .PHONY: build
 build:
-	go build -ldflags "-X 'github.com/opdev/opcap/cmd.GitCommit=$(GIT_COMMIT)' \
-		-X 'github.com/opdev/opcap/cmd.Version=$(OPCAP_VERSION)' \
-		-X 'github.com/opdev/opcap/cmd.GoVersion=$(GO_VERSION)' \
-		-X 'github.com/opdev/opcap/cmd.BuildTime=$(BUILD_TIME)' \
-		-X 'github.com/opdev/opcap/cmd.GitUser=$(GIT_USER)'" \
+	go build -ldflags "-X 'opcap/cmd.GitCommit=$(GIT_COMMIT)' \
+		-X 'opcap/cmd.Version=$(OPCAP_VERSION)' \
+		-X 'opcap/cmd.GoVersion=$(GO_VERSION)' \
+		-X 'opcap/cmd.BuildTime=$(BUILD_TIME)' \
+		-X 'opcap/cmd.GitUser=$(GIT_USER)'" \
 		-o $(BINARY) main.go
 
 .PHONY: build-multi-arch
@@ -25,8 +25,8 @@ build-multi-arch: $(addprefix build-linux-,$(ARCHITECTURES))
 define ARCHITECTURE_template
 .PHONY: build-linux-$(1)
 build-linux-$(1):
-	GOOS=linux GOARCH=$(1) go build -o $(BINARY)-linux-$(1) -ldflags "-X 'github.com/opdev/opcap/cmd.GitCommit=$(GIT_COMMIT)' \
-				-X 'github.com/opdev/opcap/cmd.Version=$(OPCAP_VERSION)'" main.go
+	GOOS=linux GOARCH=$(1) go build -o $(BINARY)-linux-$(1) -ldflags "-X 'opcap/cmd.GitCommit=$(GIT_COMMIT)' \
+				-X 'opcap/cmd.Version=$(OPCAP_VERSION)'" main.go
 endef
 
 $(foreach arch,$(ARCHITECTURES),$(eval $(call ARCHITECTURE_template,$(arch))))
@@ -44,12 +44,12 @@ tidy:
 .PHONY: test
 test:
 	go test -v $$(go list ./...) \
-	-ldflags "-X 'github.com/opdev/opcap/cmd.GitCommit=bar' -X 'github.com/opdev/opcap/cmd.Version=foo'"
+	-ldflags "-X 'opcap/cmd.GitCommit=bar' -X 'opcap/cmd.Version=foo'"
 
 .PHONY: cover
 cover:
 	go test -v \
-	 -ldflags "-X 'github.com/opdev/opcap/cmd.GitCommit=bar' -X 'github.com/opdev/opcap/cmd.Version=foo'" \
+	 -ldflags "-X 'opcap/cmd.GitCommit=bar' -X 'opcap/cmd.Version=foo'" \
 	 $$(go list ./...) \
 	 -race \
 	 -cover -coverprofile=coverage.out

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,15 @@
-.DEFAULT_GOAL:=help
-
 BINARY?=bin/opcap
 IMAGE_BUILDER?=podman
 IMAGE_REPO?=quay.io/opdev
-VERSION=$(shell git rev-parse HEAD)
-RELEASE_TAG ?= "0.0.0"
+GIT_COMMIT=$(shell git rev-parse HEAD)
+OPCAP_VERSION?="0.0.0"
 
 PLATFORMS=linux
 ARCHITECTURES=amd64 arm64 ppc64le s390x
 
 .PHONY: build
 build:
-	go build -o $(BINARY) -ldflags "-X github.com/opdev/opcap/version.commit=$(VERSION) -X github.com/opdev/opcap/version.version=$(RELEASE_TAG)" main.go
-	@ls | grep -e '^opcap$$' &> /dev/null
+	go build -o $(BINARY) -ldflags "-X github.com/opdev/opcap/version.commit=$(GIT_COMMIT) -X github.com/opdev/opcap/version.version=$(OPCAP_VERSION)" main.go
 
 .PHONY: build-multi-arch
 build-multi-arch: $(addprefix build-linux-,$(ARCHITECTURES))
@@ -20,8 +17,8 @@ build-multi-arch: $(addprefix build-linux-,$(ARCHITECTURES))
 define ARCHITECTURE_template
 .PHONY: build-linux-$(1)
 build-linux-$(1):
-	GOOS=linux GOARCH=$(1) go build -o $(BINARY)-linux-$(1) -ldflags "-X github.com/opdev/opcap/version.commit=$(VERSION) \
-				-X github.com/opdev/opcap/version.version=$(RELEASE_TAG)" main.go
+	GOOS=linux GOARCH=$(1) go build -o $(BINARY)-linux-$(1) -ldflags "-X github.com/opdev/opcap/version.commit=$(GIT_COMMIT) \
+				-X github.com/opdev/opcap/version.version=$(OPCAP_VERSION)" main.go
 endef
 
 $(foreach arch,$(ARCHITECTURES),$(eval $(call ARCHITECTURE_template,$(arch))))
@@ -35,14 +32,6 @@ fmt: gofumpt
 tidy:
 	go mod tidy -compat=1.17
 	git diff --exit-code
-
-#.PHONY: image-build
-#image-build:
-#	$(IMAGE_BUILDER) build --build-arg release_tag=$(RELEASE_TAG) --build-arg opcap_commit=$(VERSION) -t $(IMAGE_REPO)/opcap:$(VERSION) .
-
-#.PHONY: image-push
-#image-push:
-#	$(IMAGE_BUILDER) push $(IMAGE_REPO)/opcap:$(VERSION)
 
 .PHONY: test
 test:
@@ -72,7 +61,7 @@ clean:
 	$(shell if [ -f "$(BINARY)-$(GOOS)-$(GOARCH)" ]; then rm -f $(BINARY)-$(GOOS)-$(GOARCH); fi)))
 
 GOFUMPT = $(shell pwd)/bin/gofumpt
-gofumpt: ## Download envtest-setup locally if necessary.
+gofumpt: ## Download gofumpt locally if necessary.
 	$(call go-install-tool,$(GOFUMPT),mvdan.cc/gofumpt@latest)
 
 # go-get-tool will 'go get' any package $2 and install it to $1.

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,33 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+// Those variables are populated at build time by ldflags.
+// If you're running from a local debugger they will show empty fields.
+
+var Version string
+var GoVersion string
+var BuildTime string
+var GitUser string
+var GitCommit string
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Prints opcap's version information",
+	Long:  `opcap, go and git commit information for this particular binary build are included at build time and can be accessed by this command`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Version:\t", Version)
+		fmt.Println("Go Version:\t", GoVersion)
+		fmt.Println("Build Time:\t", BuildTime)
+		fmt.Println("Git User:\t", GitUser)
+		fmt.Println("Git Commit:\t", GitCommit)
+	},
+}


### PR DESCRIPTION
Two comments:
- Currently one requires access to a OCP cluster to run `opcap version`. This shouldn't be necessary. Opened https://github.com/opdev/opcap/issues/120 to track this.
- We could think of renaming the module from `opcap` to `github.com/opdev/opcap`, which is usually done in similar go projects. This requires to change imports all over the place though. I don't know if anyone has a strong preference here (I don't).
