### PR TITLE
Upload check for Succeeded, failed, or timeout

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -127,7 +127,7 @@ var uploadCmd = &cobra.Command{
 			if err := json.Unmarshal(s.Bytes(), &audit); err != nil {
 				return err
 			}
-			if audit.Message == "succeeded" || audit.Message == "failed" {
+			if audit.Message == "Succeeded" || audit.Message == "failed" || audit.Message == "timeout" {
 				report.Audits = append(report.Audits, audit)
 			}
 		}


### PR DESCRIPTION
Previously upload checked for only succeeded or failed but recent
PR changed the case of succeeded and failed does not need to be in
the log file anymore as a message.

Signed-off-by: Melvin Hillsman <mhillsma@redhat.com>