### PR TITLE
Operand status

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package cmd
 
 import (

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/opdev/opcap/internal/operator"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
@@ -52,11 +53,12 @@ type CapAudit struct {
 	// of the Audit interface
 	AuditPlan []string
 
-	// customResources is a map of string interface that has all the CR(almExamples) that needs to be installed
-	// as part of the OperandInstall function
+	// CustomResources stores CR manifests to deploy operands
 	CustomResources []map[string]interface{}
 
-	OperandStatus string
+	// Operands stores a list of unstructured custom resources that were created at the API level
+	// This data is used for further analysis on statuses, conditions and other patterns
+	Operands []unstructured.Unstructured
 }
 
 func newCapAudit(c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (CapAudit, error) {

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -89,21 +89,21 @@ func (ca *CapAudit) OperandInstall() error {
 		csv, _ := ca.Client.GetCompletedCsvWithTimeout(ca.Namespace, time.Minute)
 		if strings.ToLower(string(csv.Status.Phase)) == "succeeded" {
 			// create the resource using the dynamic client and log the error if it occurs in stdout.json
-			_, err = client.Resource(gvr).Namespace(ca.Namespace).Create(context.TODO(), obj, v1.CreateOptions{})
+			unstructuredCR, err := client.Resource(gvr).Namespace(ca.Namespace).Create(context.TODO(), obj, v1.CreateOptions{})
 			if err != nil {
-				ca.OperandStatus = "Failed"
+
 				return err
 			} else {
-				ca.OperandStatus = "Succeeded"
+				ca.Operands = append(ca.Operands, *unstructuredCR)
 			}
 		} else {
-			ca.OperandStatus = "exiting OperandInstall since CSV has failed"
+			logger.Debug("exiting OperandInstall since CSV has failed")
 		}
 	} else {
-		ca.OperandStatus = "exiting OperandInstall since no ALM_Examples found in CSV"
+		logger.Debug("exiting OperandInstall since no ALM_Examples found in CSV")
 	}
 
-	ca.Report(OperandInstallRptOptionFile{FilePath: "operand_install_report.json"}, OpInstallRptOptionPrint{})
+	ca.Report(OperandInstallRptOptionFile{FilePath: "operand_install_report.json"}, OperandInstallRptOptionPrint{})
 
 	return nil
 }

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -45,7 +45,7 @@ func (ca *CapAudit) OperatorInstall() error {
 		}
 	}
 
-	ca.Report(OpInstallRptOptionFile{FilePath: "operator_install_report.json"}, OpInstallRptOptionPrint{})
+	ca.Report(OperatorInstallRptOptionFile{FilePath: "operator_install_report.json"}, OperatorInstallRptOptionPrint{})
 
 	return nil
 }

--- a/internal/capability/report.go
+++ b/internal/capability/report.go
@@ -24,14 +24,12 @@ type ReportOption interface {
 }
 
 // Simple print option implmentation for operator install
-type OpInstallRptOptionPrint struct{}
+type OperatorInstallRptOptionPrint struct{}
 
-type OperandInstallRptOptionPrint struct{}
-
-func (OpInstallRptOptionPrint) report(ca CapAudit) error {
+func (OperatorInstallRptOptionPrint) report(ca CapAudit) error {
 
 	fmt.Println()
-	fmt.Println("opcap report:")
+	fmt.Println("Operator Install Report:")
 	fmt.Println("-----------------------------------------")
 	fmt.Printf("Report Date: %s\n", time.Now())
 	fmt.Printf("OpenShift Version: %s\n", ca.OcpVersion)
@@ -53,37 +51,12 @@ func (OpInstallRptOptionPrint) report(ca CapAudit) error {
 	return nil
 }
 
-func (OperandInstallRptOptionPrint) report(ca CapAudit) error {
-
-	fmt.Println()
-	fmt.Println("opcap report:")
-	fmt.Println("-----------------------------------------")
-	fmt.Printf("Report Date: %s\n", time.Now())
-	fmt.Printf("OpenShift Version: %s\n", ca.OcpVersion)
-	fmt.Printf("Package Name: %s\n", ca.Subscription.Package)
-
-	if !ca.CsvTimeout {
-		fmt.Printf("Result: %s\n", ca.Csv.Status.Phase)
-	} else {
-		fmt.Println("Result: timeout")
-	}
-
-	fmt.Printf("Operand Status: %s\n", ca.OperandStatus)
-	fmt.Println("-----------------------------------------")
-
-	return nil
-}
-
 // Simple file option implementation for operator install
-type OpInstallRptOptionFile struct {
+type OperatorInstallRptOptionFile struct {
 	FilePath string
 }
 
-type OperandInstallRptOptionFile struct {
-	FilePath string
-}
-
-func (opt OpInstallRptOptionFile) report(ca CapAudit) error {
+func (opt OperatorInstallRptOptionFile) report(ca CapAudit) error {
 
 	file, err := os.OpenFile(opt.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -103,6 +76,33 @@ func (opt OpInstallRptOptionFile) report(ca CapAudit) error {
 	return nil
 }
 
+// Simple print option implmentation for operand install
+type OperandInstallRptOptionPrint struct{}
+
+func (OperandInstallRptOptionPrint) report(ca CapAudit) error {
+
+	fmt.Println()
+	fmt.Println("Operand Install Report:")
+	fmt.Println("-----------------------------------------")
+	fmt.Printf("Report Date: %s\n", time.Now())
+	fmt.Printf("OpenShift Version: %s\n", ca.OcpVersion)
+	fmt.Printf("Package Name: %s\n", ca.Subscription.Package)
+
+	if len(ca.Operands) > 0 {
+		fmt.Println("Operand Creation: Succeeded")
+	} else {
+		fmt.Println("Operand Creation: Failed")
+	}
+	fmt.Println("-----------------------------------------")
+
+	return nil
+}
+
+// Simple file option implementation for operand install
+type OperandInstallRptOptionFile struct {
+	FilePath string
+}
+
 func (opt OperandInstallRptOptionFile) report(ca CapAudit) error {
 
 	file, err := os.OpenFile(opt.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -112,12 +112,12 @@ func (opt OperandInstallRptOptionFile) report(ca CapAudit) error {
 	}
 	defer file.Close()
 
-	if !ca.CsvTimeout {
+	if len(ca.Operands) > 0 {
 
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + string(ca.Csv.Status.Phase) + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\",\"operandStatus\":\"" + ca.OperandStatus + "\"}\n")
+		file.WriteString("{\"level\":\"info\",\"message\":\"" + "created" + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\"}\n")
 	} else {
 
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + "timeout" + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\",\"operandStatus\":\"" + ca.OperandStatus + "\"}\n")
+		file.WriteString("{\"level\":\"info\",\"message\":\"" + "failed" + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\"}\n")
 	}
 
 	return nil

--- a/internal/capability/report.go
+++ b/internal/capability/report.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
 func (ca CapAudit) Report(opts ...ReportOption) error {
@@ -81,12 +83,16 @@ type OperandInstallRptOptionPrint struct{}
 
 func (OperandInstallRptOptionPrint) report(ca CapAudit) error {
 
+	operand := &unstructured.Unstructured{Object: ca.CustomResources[0]}
+
 	fmt.Println()
 	fmt.Println("Operand Install Report:")
 	fmt.Println("-----------------------------------------")
 	fmt.Printf("Report Date: %s\n", time.Now())
 	fmt.Printf("OpenShift Version: %s\n", ca.OcpVersion)
 	fmt.Printf("Package Name: %s\n", ca.Subscription.Package)
+	fmt.Printf("Operand Kind: %s\n", operand.GetKind())
+	fmt.Printf("Operand Name: %s\n", operand.GetName())
 
 	if len(ca.Operands) > 0 {
 		fmt.Println("Operand Creation: Succeeded")
@@ -105,6 +111,8 @@ type OperandInstallRptOptionFile struct {
 
 func (opt OperandInstallRptOptionFile) report(ca CapAudit) error {
 
+	operand := &unstructured.Unstructured{Object: ca.CustomResources[0]}
+
 	file, err := os.OpenFile(opt.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
 		file.Close()
@@ -114,10 +122,10 @@ func (opt OperandInstallRptOptionFile) report(ca CapAudit) error {
 
 	if len(ca.Operands) > 0 {
 
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + "created" + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\"}\n")
+		file.WriteString("{\"package\":\"" + ca.Subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "created" + "\"}\n")
 	} else {
 
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + "failed" + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\"}\n")
+		file.WriteString("{\"package\":\"" + ca.Subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "failed" + "\"}\n")
 	}
 
 	return nil

--- a/main.go
+++ b/main.go
@@ -1,7 +1,3 @@
-/*
-Copyright © 2022 NAME HERE <EMAIL ADDRESS>
-
-*/
 package main
 
 import "github.com/opdev/opcap/cmd"


### PR DESCRIPTION
Here is a summary of the commits on this PR. All of them are well commented.

The problem it solves is making the status, conditions and phases for the operands available. It's being stored in the Audit object now. How to treat that information will be considered a subsequent issue.

Quick view on the commits:

1) Cleanup generic header from cobra cli tool - just an unrelated but pretty quick fix

2) Reorganize operand report and data collection - all status, conditions, phase and the whole operand object was included here. We still need to move towards trying all CRs available instead of getting just the first. To be treated on a separate issue.

3) ADD operand kind and name to report - Improves the operand report with pertinent information