### PR TITLE
fix package manifest filtering feature in ListPackageManifests() method

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -45,7 +45,7 @@ Flags:
 			return types.Error{Msg: "Unable to create OpCap client."}
 		}
 		var packageManifestList pkgserverv1.PackageManifestList
-		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.FilterPackages)
+		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.CatalogSource, checkflags.FilterPackages)
 		if err != nil {
 			return types.Error{Msg: "Unable to list PackageManifests."}
 		}
@@ -64,8 +64,6 @@ Flags:
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("check called")
-
 		// Build auditor by catalog
 		auditor, err := capability.BuildAuditorByCatalog(checkflags.CatalogSource, checkflags.CatalogSourceNamespace, checkflags.AuditPlan, checkflags.FilterPackages)
 		if err != nil {

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -34,7 +34,7 @@ type Client interface {
 	DeleteSubscription(ctx context.Context, name string, namespace string) error
 	GetCompletedCsvWithTimeout(namespace string, delay time.Duration) (operatorv1alpha1.ClusterServiceVersion, error)
 	GetOpenShiftVersion() (string, error)
-	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, filter []string) error
+	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, catalogSource string, filter []string) error
 	GetSubscriptionData(source string, namespace string, filter []string) ([]SubscriptionData, error)
 	ListCRDs(ctx context.Context, list *apiextensionsv1.CustomResourceDefinitionList) error
 }

--- a/internal/operator/subscription_test.go
+++ b/internal/operator/subscription_test.go
@@ -1,0 +1,93 @@
+package operator
+
+import (
+	"testing"
+
+	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var manifests = []pkgserverv1.PackageManifest{
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mongodb-atlas-kubernetes",
+			Namespace: "openshift-marketplace",
+		},
+		Spec: pkgserverv1.PackageManifestSpec{},
+		Status: pkgserverv1.PackageManifestStatus{
+			PackageName:   "mongodb-atlas-kubernetes",
+			CatalogSource: "certified-operators",
+		},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "mongodb-atlas-kubernetes",
+			Namespace: "openshift-marketplace",
+		},
+		Spec: pkgserverv1.PackageManifestSpec{},
+		Status: pkgserverv1.PackageManifestStatus{
+			PackageName:   "mongodb-atlas-kubernetes",
+			CatalogSource: "community-operators",
+		},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "argocd-operator",
+			Namespace: "openshift-marketplace",
+		},
+		Spec: pkgserverv1.PackageManifestSpec{},
+		Status: pkgserverv1.PackageManifestStatus{
+			PackageName:   "argocd-operator",
+			CatalogSource: "certified-operators",
+		},
+	},
+	{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pachyderm-operator",
+			Namespace: "openshift-marketplace",
+		},
+		Spec: pkgserverv1.PackageManifestSpec{},
+		Status: pkgserverv1.PackageManifestStatus{
+			PackageName:   "pachyderm-operator",
+			CatalogSource: "certified-operators",
+		},
+	},
+}
+
+func TestFilterPackageManifests(t *testing.T) {
+	var cases = []struct {
+		catalog string
+		filters []string
+		expect  int
+	}{
+		{
+			catalog: "",
+			filters: []string{},
+			expect:  4,
+		},
+		{
+			catalog: "certified-operators",
+			filters: []string{},
+			expect:  3,
+		},
+		{
+			catalog: "",
+			filters: []string{"mongodb-atlas-kubernetes"},
+			expect:  2,
+		},
+		{
+			catalog: "certified-operators",
+			filters: []string{"mongodb-atlas-kubernetes"},
+			expect:  1,
+		},
+	}
+
+	for i, testcase := range cases {
+		t.Logf("Test %d => catalog sources: \"%s\", filters: %+v", i, testcase.catalog, testcase.filters)
+		results := filterPackageManifests(manifests, testcase.catalog, testcase.filters)
+		if len(results) != testcase.expect {
+			t.Errorf("expected %d, received %d results", testcase.expect, len(results))
+		}
+		t.Logf("matched %d out of %d package manifests", len(results), len(manifests))
+	}
+}


### PR DESCRIPTION
Filtering by catalog source was not being honored which would result in multiple package manifests
being returned if the same package name existed in different catalog sources.

In addition, we moved the filtering functionality to a separate function
to make it easier to test

Closes #166

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>