### PR TITLE
Add validation for --filter-packages

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -47,7 +47,7 @@ Flags:
 		var packageManifestList pkgserverv1.PackageManifestList
 		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.CatalogSource, checkflags.FilterPackages)
 		if err != nil {
-			return types.Error{Msg: "Unable to list PackageManifests."}
+			return types.Error{Msg: "Unable to list PackageManifests.\n" + err.Error()}
 		}
 
 		if len(packageManifestList.Items) == 0 {


### PR DESCRIPTION
If any of the requested package names in --filter-packages are not found in the catalog source(s), then show an error that states which packages were not found.

Fixes #117