### PR TITLE
support testing all install modes supported by an operator

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -45,7 +45,7 @@ Flags:
 			return types.Error{Msg: "Unable to create OpCap client."}
 		}
 		var packageManifestList pkgserverv1.PackageManifestList
-		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.CatalogSource, checkflags.FilterPackages)
+		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags)
 		if err != nil {
 			return types.Error{Msg: "Unable to list PackageManifests.\n" + err.Error()}
 		}
@@ -65,7 +65,7 @@ Flags:
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Build auditor by catalog
-		auditor, err := capability.BuildAuditorByCatalog(checkflags.CatalogSource, checkflags.CatalogSourceNamespace, checkflags.AuditPlan, checkflags.FilterPackages)
+		auditor, err := capability.BuildAuditorByCatalog(checkflags)
 		if err != nil {
 			logger.Sugar.Fatal("Unable to build auditor")
 		}
@@ -74,15 +74,7 @@ Flags:
 	},
 }
 
-type CheckCommandFlags struct {
-	AuditPlan              []string `json:"auditPlan"`
-	CatalogSource          string   `json:"catalogsource"`
-	CatalogSourceNamespace string   `json:"catalogsourcenamespace"`
-	ListPackages           bool     `json:"listPackages"`
-	FilterPackages         []string `json:"filterPackages"`
-}
-
-var checkflags CheckCommandFlags
+var checkflags operator.OperatorCheckOptions
 
 func init() {
 
@@ -98,4 +90,5 @@ func init() {
 	flags.StringSliceVar(&checkflags.AuditPlan, "auditplan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
 	flags.BoolVar(&checkflags.ListPackages, "list-packages", false, "list packages in the catalog")
 	flags.StringSliceVar(&checkflags.FilterPackages, "filter-packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
+	flags.BoolVar(&checkflags.AllInstallModes, "all-installmodes", false, "when set, all install modes supported by an operator will be tested")
 }

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -63,7 +63,8 @@ type CapAudit struct {
 
 func newCapAudit(c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (CapAudit, error) {
 
-	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-")}, "-")
+	// TODO: optimize performance by re-using the namespace for the same operator
+	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-"), strings.ToLower(string(subscription.InstallModeType))}, "-")
 	operatorGroupName := strings.Join([]string{subscription.Name, subscription.Channel, "group"}, "-")
 
 	ocpVersion, err := c.GetOpenShiftVersion()

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -10,7 +10,7 @@ import (
 // It has methods to create a workqueue with all the package and audit requirements for a
 // particular audit run
 type Auditor interface {
-	BuildWorkQueueByCatalog(catalogSource string, catalogSourceNamespace string, auditPlan []string) error
+	BuildWorkQueueByCatalog(opts operator.OperatorCheckOptions) error
 	RunAudits() error
 }
 
@@ -22,10 +22,10 @@ type capAuditor struct {
 }
 
 // BuildAuditorByCatalog creates a new Auditor with workqueue based on a selected catalog
-func BuildAuditorByCatalog(catalogSource string, catalogSourceNamespace string, auditPlan []string, filter []string) (capAuditor, error) {
+func BuildAuditorByCatalog(options operator.OperatorCheckOptions) (capAuditor, error) {
 
 	var auditor capAuditor
-	err := auditor.BuildWorkQueueByCatalog(catalogSource, catalogSourceNamespace, auditPlan, filter)
+	err := auditor.BuildWorkQueueByCatalog(options)
 	if err != nil {
 		logger.Fatalf("Unable to build workqueue err := %s", err.Error())
 	}
@@ -33,7 +33,7 @@ func BuildAuditorByCatalog(catalogSource string, catalogSourceNamespace string, 
 }
 
 // BuildWorkQueueByCatalog fills in the auditor workqueue with all package information found in a specific catalog
-func (capAuditor *capAuditor) BuildWorkQueueByCatalog(catalogSource string, catalogSourceNamespace string, auditPlan []string, filter []string) error {
+func (capAuditor *capAuditor) BuildWorkQueueByCatalog(options operator.OperatorCheckOptions) error {
 
 	c, err := operator.NewOpCapClient()
 	if err != nil {
@@ -43,20 +43,20 @@ func (capAuditor *capAuditor) BuildWorkQueueByCatalog(catalogSource string, cata
 	}
 
 	// Getting subscription data form the package manifests available in the selected catalog
-	s, err := c.GetSubscriptionData(catalogSource, catalogSourceNamespace, filter)
+	subscriptions, err := c.GetSubscriptionData(options)
 	if err != nil {
-		logger.Errorf("Error while getting bundles from CatalogSource %s: %w", catalogSource, err)
+		logger.Errorf("Error while getting bundles from CatalogSource %s: %w", options.CatalogSource, err)
 		return err
 	}
 
 	// build workqueue as buffered channel based subscriptionData list size
-	capAuditor.WorkQueue = make(chan CapAudit, len(s))
+	capAuditor.WorkQueue = make(chan CapAudit, len(subscriptions))
 	defer close(capAuditor.WorkQueue)
 
 	// add capAudits to the workqueue
-	for _, subscription := range s {
+	for _, subscription := range subscriptions {
 
-		capAudit, err := newCapAudit(c, subscription, auditPlan)
+		capAudit, err := newCapAudit(c, subscription, options.AuditPlan)
 		if err != nil {
 			logger.Debugf("Couldn't build capAudit for subscription %s", "Err:", err)
 			return err

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -34,13 +34,31 @@ type Client interface {
 	DeleteSubscription(ctx context.Context, name string, namespace string) error
 	GetCompletedCsvWithTimeout(namespace string, delay time.Duration) (operatorv1alpha1.ClusterServiceVersion, error)
 	GetOpenShiftVersion() (string, error)
-	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, catalogSource string, filter []string) error
-	GetSubscriptionData(source string, namespace string, filter []string) ([]SubscriptionData, error)
+	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, opts OperatorCheckOptions) error
+	GetSubscriptionData(options OperatorCheckOptions) ([]SubscriptionData, error)
 	ListCRDs(ctx context.Context, list *apiextensionsv1.CustomResourceDefinitionList) error
 }
 
 type operatorClient struct {
 	Client runtimeClient.Client
+}
+
+type OperatorCheckOptions struct {
+	// AuditPlan is an ordered list of tests to be run
+	// during an operator audit
+	AuditPlan []string
+	// CatalogSource provides target catalog source
+	// from which to list package manifests
+	CatalogSource string
+	// CatalogSourceNamespace specifies the namespace of the
+	// catalog source to be used
+	CatalogSourceNamespace string
+	// ListPackages operation lists packages in the catalog source
+	ListPackages bool
+	// FilterPackages provides a list of packages to find
+	FilterPackages []string
+	// AllInstallModes is passed to test all install modes
+	AllInstallModes bool
 }
 
 func NewOpCapClient() (Client, error) {


### PR DESCRIPTION
This commit allows the testing of all install modes that are supported
by an operator.

To accomplish this, the following changes were made:
- return unique subscription names in GetSubscriptionsData method
- return unique namespaces for each install mode tested
- test all install modes when the "--all-installmodes" flag is passed
- rename CheckCommandFlags struct to OperatorCheckOptions and move to the operator package

Closes #51 

Signed-off-by: Edmund Ochieng <ochienged@gmail.com>