### PR TITLE
Simplify and refactor cmd/ package

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,13 +1,10 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
-	"go/types"
 	"os"
 
 	"github.com/opdev/opcap/internal/capability"
-	"github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
 
 	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
@@ -15,73 +12,69 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// TODO: provide godoc compatible comment for checkCmd
-var checkCmd = &cobra.Command{
-	Use: "check",
-	// TODO: provide Short description for check command
-	Short: "Checks if operator meets minimum capability requirement.",
-	// TODO: provide Long description for check command
-	Long: `The 'check' command checks if OpenShift operators meet minimum
-requirements for Operator Capabilities Level to attest operator
-advanced features by running custom resources provided by CSVs
-and/or users.
-
-Usage:
-opcap check [flags]
-
-Example:
-opcap check --catalogsource=certified-operators --catalogsourcenamespace=openshift-marketplace --list-packages=false'
-
-Flags:
---catalogsource				specifies the catalogsource to test against
---catalogsourcenamespace	specifies the namespace where the catalogsource exists
---auditplan					audit plan is the ordered list of operator test functions to be called during a capability audit
---list-packages				list packages in the catalog
---filter-packages			a list of package(s) which limits audits and/or other flag(s) output
-`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		psc, err := operator.NewOpCapClient()
-		if err != nil {
-			return types.Error{Msg: "Unable to create OpCap client."}
-		}
-		var packageManifestList pkgserverv1.PackageManifestList
-		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags)
-		if err != nil {
-			return types.Error{Msg: "Unable to list PackageManifests.\n" + err.Error()}
-		}
-
-		if len(packageManifestList.Items) == 0 {
-			return types.Error{Msg: "No PackageManifests returned from PackageServer."}
-		}
-
-		if checkflags.ListPackages {
-			for _, packageManifest := range packageManifestList.Items {
-				fmt.Println(packageManifest.Name)
-			}
-			os.Exit(0)
-		}
-
-		return nil
-	},
-	Run: func(cmd *cobra.Command, args []string) {
-		// Build auditor by catalog
-		auditor, err := capability.BuildAuditorByCatalog(checkflags)
-		if err != nil {
-			logger.Sugar.Fatal("Unable to build auditor")
-		}
-		// run all dynamically built audits in the auditor workqueue
-		auditor.RunAudits()
-	},
-}
-
 var checkflags operator.OperatorCheckOptions
 
-func init() {
+// TODO: provide godoc compatible comment for checkCmd
+func checkCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "check",
+		Short: "Checks if operator meets minimum capability requirement.",
+		Long: `The 'check' command checks if OpenShift operators meet minimum
+requirements for Operator Capabilities Level to attest operator
+advanced features by running custom resources provided by CSVs
+and/or users.`,
+		Example: `opcap check --catalogsource=certified-operators --catalogsourcenamespace=openshift-marketplace --list-packages=false'`,
+		PreRunE: func(cmd *cobra.Command, args []string) error {
+			if checkflags.ListPackages {
+				psc, err := operator.NewOpCapClient()
+				if err != nil {
+					return fmt.Errorf("unable to create OpCap client: %v", err)
+				}
+				var packageManifestList pkgserverv1.PackageManifestList
+				err = psc.ListPackageManifests(cmd.Parent().Context(), &packageManifestList, checkflags)
+				if err != nil {
+					return fmt.Errorf("unable to list PackageManifests: %v", err)
+				}
 
-	var defaultAuditPlan = []string{"OperatorInstall", "OperatorCleanUp"}
+				if len(packageManifestList.Items) == 0 {
+					return fmt.Errorf("no PackageManifests returned from PackageServer")
+				}
 
-	rootCmd.AddCommand(checkCmd)
-	flags := checkCmd.Flags()
+				for _, packageManifest := range packageManifestList.Items {
+					fmt.Println(packageManifest.Name)
+				}
+				os.Exit(0)
+			}
+
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			psc, err := operator.NewOpCapClient()
+			if err != nil {
+				return fmt.Errorf("unable to create OpCap client: %v", err)
+			}
+			var packageManifestList pkgserverv1.PackageManifestList
+			err = psc.ListPackageManifests(cmd.Parent().Context(), &packageManifestList, checkflags)
+			if err != nil {
+				return fmt.Errorf("unable to list PackageManifests: %v", err)
+			}
+
+			if len(packageManifestList.Items) == 0 {
+				return fmt.Errorf("no PackageManifests returned from PackageServer")
+			}
+			// Build auditor by catalog
+			auditor, err := capability.BuildAuditorByCatalog(checkflags)
+			if err != nil {
+				return err
+			}
+			// run all dynamically built audits in the auditor workqueue
+			return auditor.RunAudits()
+		},
+	}
+
+	defaultAuditPlan := []string{"OperatorInstall", "OperatorCleanUp"}
+
+	flags := cmd.Flags()
 
 	flags.StringVar(&checkflags.CatalogSource, "catalogsource", "certified-operators",
 		"specifies the catalogsource to test against")
@@ -91,4 +84,6 @@ func init() {
 	flags.BoolVar(&checkflags.ListPackages, "list-packages", false, "list packages in the catalog")
 	flags.StringSliceVar(&checkflags.FilterPackages, "filter-packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
 	flags.BoolVar(&checkflags.AllInstallModes, "all-installmodes", false, "when set, all install modes supported by an operator will be tested")
+
+	return &cmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,33 +1,36 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
+	"context"
 
 	"github.com/spf13/cobra"
 )
 
 // rootCmd represents the base command when called without any subcommands
-var rootCmd = &cobra.Command{
-	Use:   "opcap",
-	Short: "A brief description of your application",
-	Long: `A longer description that spans multiple lines and likely contains
+func rootCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "opcap",
+		Short: "A brief description of your application",
+		Long: `A longer description that spans multiple lines and likely contains
 examples and usage of using your application. For example:
 
 Cobra is a CLI library for Go that empowers applications.
 This application is a tool to generate the needed files
 to quickly create a Cobra application.`,
-	// Uncomment the following line if your bare application
-	// has an action associated with it:
-	// Run: func(cmd *cobra.Command, args []string) { },
+		// Uncomment the following line if your bare application
+		// has an action associated with it:
+		// Run: func(cmd *cobra.Command, args []string) { },
+	}
+
+	cmd.AddCommand(checkCmd())
+	cmd.AddCommand(uploadCmd())
+	cmd.AddCommand(versionCmd())
+
+	return &cmd
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
-	err := rootCmd.Execute()
-	if err != nil {
-		fmt.Fprintln(os.Stderr, "Opcap tool execution failed: ", err)
-		os.Exit(1)
-	}
+func Execute() error {
+	return rootCmd().ExecuteContext(context.Background())
 }

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -1,156 +1,28 @@
 package cmd
 
 import (
-	"bufio"
-	"context"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"os"
-	"strconv"
-	"time"
-
-	"github.com/opdev/opcap/internal/operator"
+	"github.com/opdev/opcap/internal/upload"
 
 	"github.com/gobuffalo/envy"
-	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/cobra"
 )
 
 var osversion string
 
-type UploadCommandFlags struct {
-	Bucket          string `json:"bucket"`
-	Path            string `json:"path"`
-	Endpoint        string `json:"endpoint"`
-	AccessKeyID     string `json:"accesskeyid"`
-	SecretAccessKey string `json:"secretaccesskey"`
-	UseSSL          string `json:"usessl"`
-	Trace           string `json:"trace"`
-}
-
-type Report struct {
-	Catalog          string  `json:"catalog"`
-	CatalogNamespace string  `json:"catalognamespace"`
-	OpenShiftVersion string  `json:"osversion"`
-	Audits           []Audit `json:"audits"`
-}
-
-type Audit struct {
-	Message     string `json:"message"`
-	Package     string `json:"package,omitempty"`
-	Channel     string `json:"channel,omitempty"`
-	InstallMode string `json:"installmode,omitempty"`
-}
-
-// constants for time/date formatting
-const (
-	// YYYYMMDD: 20220323
-	YYYYMMDD = "20060102"
-	// 24h hhmmss: 142320
-	HHMMSS24h = "150405"
-)
-
-var uploadflags UploadCommandFlags
+var uploadflags upload.UploadOptions
 
 // uploadCmd is used to upload objects to an S3 compatible backend using the MinIO client
-var uploadCmd = &cobra.Command{
-	Use:   "upload",
-	Short: "Upload audit logs to an S3 compatible storage service.",
-	Long:  `Upload audit logs to an S3 compatible storage service.`,
-	PreRunE: func(cmd *cobra.Command, args []string) error {
-		opClient, err := operator.NewOpCapClient()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Failed to initialize OpenShift client: ", err)
-			os.Exit(1)
-		}
+func uploadCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "upload",
+		Short: "Upload audit logs to an S3 compatible storage service.",
+		Long:  `Upload audit logs to an S3 compatible storage service.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return upload.Upload(cmd.Parent().Context(), uploadflags, checkflags.CatalogSource, checkflags.CatalogSourceNamespace)
+		},
+	}
 
-		osversion, err = opClient.GetOpenShiftVersion()
-		if err != nil {
-			fmt.Fprintln(os.Stderr, "Failed to connect to OpenShift: ", err)
-			os.Exit(1)
-		}
-
-		return nil
-	},
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// Convert uploadflags.UseSSL and Trace to bool
-		usessl, _ := strconv.ParseBool(uploadflags.UseSSL)
-		trace, _ := strconv.ParseBool(uploadflags.Trace)
-
-		// Create a minio client to interact with minio object store
-		minioClient, err := minio.New(uploadflags.Endpoint, &minio.Options{
-			Creds:  credentials.NewStaticV4(uploadflags.AccessKeyID, uploadflags.SecretAccessKey, ""),
-			Secure: usessl,
-		})
-		if err != nil {
-			return err
-		}
-
-		if trace {
-			minioClient.TraceOn(os.Stdout)
-		}
-
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-
-		// check for bucket, create if it does not exist
-		now := time.Now()
-		if uploadflags.Bucket == "" {
-			uploadflags.Bucket = now.Format(YYYYMMDD)
-		}
-		prefix := now.Format(HHMMSS24h)
-
-		if ok, _ := minioClient.BucketExists(ctx, uploadflags.Bucket); !ok {
-			minioClient.MakeBucket(ctx, uploadflags.Bucket, minio.MakeBucketOptions{})
-		}
-
-		var report Report
-
-		report.OpenShiftVersion = osversion
-		report.Catalog = checkflags.CatalogSource
-		report.CatalogNamespace = checkflags.CatalogSourceNamespace
-
-		// for each line is stdout.json which is provided by opcap create an Audit object and add to the rawreport Audits field.
-		f, err := os.Open("operator_install_report.json")
-		if err != nil {
-			return err
-		}
-		s := bufio.NewScanner(f)
-		for s.Scan() {
-			var audit Audit
-			if err := json.Unmarshal(s.Bytes(), &audit); err != nil {
-				return err
-			}
-			if audit.Message == "Succeeded" || audit.Message == "failed" || audit.Message == "timeout" {
-				report.Audits = append(report.Audits, audit)
-			}
-		}
-		data, err := json.Marshal(report)
-		if err != nil {
-			return err
-		}
-
-		if err = ioutil.WriteFile("report.json", data, 0o644); err != nil {
-			return err
-		}
-
-		if uploadflags.Path == "" {
-			uploadflags.Path = osversion + "/" + prefix + "_report.json"
-		}
-		_, err = minioClient.FPutObject(ctx, uploadflags.Bucket, uploadflags.Path, "report.json", minio.PutObjectOptions{ContentType: "application/json"})
-		if err != nil {
-			return err
-		}
-
-		return nil
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(uploadCmd)
-	flags := uploadCmd.Flags()
+	flags := cmd.Flags()
 
 	flags.StringVar(&uploadflags.Bucket, "bucket", envy.Get("S3_BUCKET", ""),
 		"s3 bucket where result will be stored")
@@ -166,4 +38,6 @@ func init() {
 		"when used s3 backend is expected to be accessible via https; false by default")
 	flags.StringVar(&uploadflags.Trace, "trace", envy.Get("TRACE", "false"),
 		"enable tracing; false by default")
+
+	return &cmd
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,28 +6,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func init() {
-	rootCmd.AddCommand(versionCmd)
-}
-
 // Those variables are populated at build time by ldflags.
 // If you're running from a local debugger they will show empty fields.
 
-var Version string
-var GoVersion string
-var BuildTime string
-var GitUser string
-var GitCommit string
+var (
+	Version   string
+	GoVersion string
+	BuildTime string
+	GitUser   string
+	GitCommit string
+)
 
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Prints opcap's version information",
-	Long:  `opcap, go and git commit information for this particular binary build are included at build time and can be accessed by this command`,
-	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("Version:\t", Version)
-		fmt.Println("Go Version:\t", GoVersion)
-		fmt.Println("Build Time:\t", BuildTime)
-		fmt.Println("Git User:\t", GitUser)
-		fmt.Println("Git Commit:\t", GitCommit)
-	},
+func versionCmd() *cobra.Command {
+	cmd := cobra.Command{
+		Use:   "version",
+		Short: "Prints opcap's version information",
+		Long:  `opcap, go and git commit information for this particular binary build are included at build time and can be accessed by this command`,
+		Run: func(cmd *cobra.Command, args []string) {
+			fmt.Fprintf(cmd.OutOrStdout(), "Version:\t%s\n", Version)
+			fmt.Fprintf(cmd.OutOrStdout(), "Go Version:\t%s\n", GoVersion)
+			fmt.Fprintf(cmd.OutOrStdout(), "Build Time:\t%s\n", BuildTime)
+			fmt.Fprintf(cmd.OutOrStdout(), "Git User:\t%s\n", GitUser)
+			fmt.Fprintf(cmd.OutOrStdout(), "Git Commit:\t%s\n", GitCommit)
+		},
+	}
+
+	return &cmd
 }

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
@@ -80,7 +79,11 @@ func NewOpCapClient() (Client, error) {
 		return nil, err
 	}
 
-	client, err := runtimeClient.New(kubeConfig(), runtimeClient.Options{Scheme: scheme})
+	kubeConfig, err := kubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("could not get kubeconfig: %v", err)
+	}
+	client, err := runtimeClient.New(kubeConfig, runtimeClient.Options{Scheme: scheme})
 	if err != nil {
 		logger.Errorf("could not get subscription client")
 		return nil, err
@@ -93,43 +96,56 @@ func NewOpCapClient() (Client, error) {
 }
 
 // kubeConfig return kubernetes cluster config
-func kubeConfig() *rest.Config {
+func kubeConfig() (*rest.Config, error) {
 	config, err := ctrl.GetConfig()
 	if err != nil {
 		// returned when there is no kubeconfig
 		if errors.Is(err, clientcmd.ErrEmptyConfig) {
-			fmt.Println("please provide kubeconfig before retrying")
-			os.Exit(1)
+			return nil, fmt.Errorf("please provide kubeconfig before retrying")
 		}
 
 		// returned when the kubeconfig has no servers
 		if errors.Is(err, clientcmd.ErrEmptyCluster) {
-			fmt.Println("malformed kubeconfig. Please check before retrying")
-			os.Exit(1)
+			return nil, fmt.Errorf("malformed kubeconfig. Please check before retrying")
 		}
 
 		// any other errors getting kubeconfig would be caught here
-		fmt.Println("error getting kubeconfig. Please check before retrying")
-		os.Exit(1)
+		return nil, fmt.Errorf("error getting kubeconfig. Please check before retrying")
 	}
-	return config
+	return config, nil
 }
 
 func NewOlmClientset() (*olmclient.Clientset, error) {
-	return olmclient.NewForConfig(kubeConfig())
+	kubeConfig, err := kubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	return olmclient.NewForConfig(kubeConfig)
 }
 
 // NewDynamicClient creates a new dynamic client or returns an error.
 func NewDynamicClient() (dynamic.Interface, error) {
-	return dynamic.NewForConfig(kubeConfig())
+	kubeConfig, err := kubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	return dynamic.NewForConfig(kubeConfig)
 }
 
 // NewKubernetesClient returns a kubernetes clientset
 func NewKubernetesClient() (*kubernetes.Clientset, error) {
-	return kubernetes.NewForConfig(kubeConfig())
+	kubeConfig, err := kubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	return kubernetes.NewForConfig(kubeConfig)
 }
 
 func NewConfigClient() (*configv1.ConfigV1Client, error) {
 	// create openshift config clientset
-	return configv1.NewForConfig(kubeConfig())
+	kubeConfig, err := kubeConfig()
+	if err != nil {
+		return nil, err
+	}
+	return configv1.NewForConfig(kubeConfig)
 }

--- a/internal/upload/upload.go
+++ b/internal/upload/upload.go
@@ -1,0 +1,137 @@
+package upload
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/opdev/opcap/internal/operator"
+)
+
+// constants for time/date formatting
+const (
+	// YYYYMMDD: 20220323
+	YYYYMMDD = "20060102"
+	// 24h hhmmss: 142320
+	HHMMSS24h = "150405"
+)
+
+type UploadOptions struct {
+	Bucket          string `json:"bucket"`
+	Path            string `json:"path"`
+	Endpoint        string `json:"endpoint"`
+	AccessKeyID     string `json:"accesskeyid"`
+	SecretAccessKey string `json:"secretaccesskey"`
+	UseSSL          string `json:"usessl"`
+	Trace           string `json:"trace"`
+}
+
+type auditReport struct {
+	Catalog          string  `json:"catalog"`
+	CatalogNamespace string  `json:"catalognamespace"`
+	OpenShiftVersion string  `json:"osversion"`
+	Audits           []audit `json:"audits"`
+}
+
+type audit struct {
+	Message     string `json:"message"`
+	Package     string `json:"package,omitempty"`
+	Channel     string `json:"channel,omitempty"`
+	InstallMode string `json:"installmode,omitempty"`
+}
+
+func initClient() (operator.Client, error) {
+	opClient, err := operator.NewOpCapClient()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize OpenShift client: %v", err)
+	}
+	return opClient, nil
+}
+
+func Upload(ctx context.Context, options UploadOptions, catalogSource, catalogSourceNamespace string) error {
+	client, err := initClient()
+	if err != nil {
+		return err
+	}
+	osversion, err := client.GetOpenShiftVersion()
+	if err != nil {
+		return fmt.Errorf("failed to connect to OpenShift: %v", err)
+	}
+
+	// Convert uploadflags.UseSSL and Trace to bool
+	useSSL, _ := strconv.ParseBool(options.UseSSL)
+	trace, _ := strconv.ParseBool(options.Trace)
+
+	// Create a minio client to interact with minio object store
+	minioClient, err := minio.New(options.Endpoint, &minio.Options{
+		Creds:  credentials.NewStaticV4(options.AccessKeyID, options.SecretAccessKey, ""),
+		Secure: useSSL,
+	})
+	if err != nil {
+		return err
+	}
+
+	if trace {
+		minioClient.TraceOn(os.Stdout)
+	}
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	// check for bucket, create if it does not exist
+	now := time.Now()
+	if options.Bucket == "" {
+		options.Bucket = now.Format(YYYYMMDD)
+	}
+	prefix := now.Format(HHMMSS24h)
+
+	if ok, _ := minioClient.BucketExists(ctx, options.Bucket); !ok {
+		minioClient.MakeBucket(ctx, options.Bucket, minio.MakeBucketOptions{})
+	}
+
+	var report auditReport
+
+	report.OpenShiftVersion = osversion
+	report.Catalog = catalogSource
+	report.CatalogNamespace = catalogSourceNamespace
+
+	// for each line is stdout.json which is provided by opcap create an Audit object and add to the rawreport Audits field.
+	f, err := os.Open("operator_install_report.json")
+	if err != nil {
+		return err
+	}
+	s := bufio.NewScanner(f)
+	for s.Scan() {
+		var audit audit
+		if err := json.Unmarshal(s.Bytes(), &audit); err != nil {
+			return err
+		}
+		if audit.Message == "Succeeded" || audit.Message == "failed" || audit.Message == "timeout" {
+			report.Audits = append(report.Audits, audit)
+		}
+	}
+	data, err := json.Marshal(report)
+	if err != nil {
+		return err
+	}
+
+	if err = os.WriteFile("report.json", data, 0o644); err != nil {
+		return err
+	}
+
+	if options.Path == "" {
+		options.Path = osversion + "/" + prefix + "_report.json"
+	}
+	_, err = minioClient.FPutObject(ctx, options.Bucket, options.Path, "report.json", minio.PutObjectOptions{ContentType: "application/json"})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/main.go
+++ b/main.go
@@ -1,7 +1,12 @@
 package main
 
-import "github.com/opdev/opcap/cmd"
+import (
+	"github.com/opdev/opcap/cmd"
+	"github.com/opdev/opcap/internal/logger"
+)
 
 func main() {
-	cmd.Execute()
+	if err := cmd.Execute(); err != nil {
+		logger.Sugar.Fatal(err)
+	}
 }


### PR DESCRIPTION
* Send the same context down from main
* Move upload to an internal package
* Get rid of init()'s in cmd/
* Take out redundant text from check long description

Refers to #187 

Signed-off-by: Brad P. Crochet <brad@redhat.com>