### PR TITLE
Adding a GH Action for testing a pull request

### DIFF
--- a/.github/workflows/ciTest.yml
+++ b/.github/workflows/ciTest.yml
@@ -1,0 +1,39 @@
+name: CI Test
+
+on:
+  pull_request:
+    branches:
+    - main
+    - release-*
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.18
+
+    - name: Tidy
+      run: make tidy
+
+    - name: Vet
+      run: make vet
+
+    - name: Format
+      run: make fmt
+
+    - name: Test
+      run: make cover
+
+    - name: Convert coverage.out to coverage.lcov
+      uses: jandelgado/gcov2lcov-action@v1.0.9
+    
+    - name: Coveralls
+      uses: coverallsapp/github-action@v1.1.2
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        path-to-lcov: coverage.lcov


### PR DESCRIPTION
The following action will do the following on a PR to main:
1. run gofumpt on the code.
2. integrate with Coveralls for a coverage score.

Signed-off-by: Igor Troyanovsky <itroyano@redhat.com>