### PR TITLE
Refactor decouple

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	"github.com/opdev/opcap/internal/capability"
-	"github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
 
 	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
@@ -64,13 +63,16 @@ Flags:
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		// Build auditor by catalog
-		auditor, err := capability.BuildAuditorByCatalog(checkflags.CatalogSource, checkflags.CatalogSourceNamespace, checkflags.AuditPlan, checkflags.FilterPackages)
-		if err != nil {
-			logger.Sugar.Fatal("Unable to build auditor")
+
+		capAuditor := &capability.CapAuditor{
+			AuditPlan:              checkflags.AuditPlan,
+			CatalogSource:          checkflags.CatalogSource,
+			CatalogSourceNamespace: checkflags.CatalogSourceNamespace,
+			FilterPackages:         checkflags.FilterPackages,
 		}
+
 		// run all dynamically built audits in the auditor workqueue
-		auditor.RunAudits()
+		capAuditor.RunAudits()
 	},
 }
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -96,7 +96,7 @@ func init() {
 		"specifies the catalogsource to test against")
 	flags.StringVar(&checkflags.CatalogSourceNamespace, "catalogsourcenamespace", "openshift-marketplace",
 		"specifies the namespace where the catalogsource exists")
-	flags.StringSliceVar(&checkflags.AuditPlan, "auditplan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
+	flags.StringSliceVar(&checkflags.AuditPlan, "audit-plan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
 	flags.BoolVar(&checkflags.ListPackages, "list-packages", false, "list packages in the catalog")
 	flags.StringSliceVar(&checkflags.Packages, "packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -45,7 +45,7 @@ Flags:
 			return types.Error{Msg: "Unable to create OpCap client."}
 		}
 		var packageManifestList pkgserverv1.PackageManifestList
-		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags)
+		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.CatalogSource, checkflags.FilterPackages)
 		if err != nil {
 			return types.Error{Msg: "Unable to list PackageManifests.\n" + err.Error()}
 		}
@@ -65,7 +65,7 @@ Flags:
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		// Build auditor by catalog
-		auditor, err := capability.BuildAuditorByCatalog(checkflags)
+		auditor, err := capability.BuildAuditorByCatalog(checkflags.CatalogSource, checkflags.CatalogSourceNamespace, checkflags.AuditPlan, checkflags.FilterPackages)
 		if err != nil {
 			logger.Sugar.Fatal("Unable to build auditor")
 		}
@@ -74,7 +74,15 @@ Flags:
 	},
 }
 
-var checkflags operator.OperatorCheckOptions
+type CheckCommandFlags struct {
+	AuditPlan              []string `json:"auditPlan"`
+	CatalogSource          string   `json:"catalogsource"`
+	CatalogSourceNamespace string   `json:"catalogsourcenamespace"`
+	ListPackages           bool     `json:"listPackages"`
+	FilterPackages         []string `json:"filterPackages"`
+}
+
+var checkflags CheckCommandFlags
 
 func init() {
 
@@ -90,5 +98,4 @@ func init() {
 	flags.StringSliceVar(&checkflags.AuditPlan, "auditplan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
 	flags.BoolVar(&checkflags.ListPackages, "list-packages", false, "list packages in the catalog")
 	flags.StringSliceVar(&checkflags.FilterPackages, "filter-packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
-	flags.BoolVar(&checkflags.AllInstallModes, "all-installmodes", false, "when set, all install modes supported by an operator will be tested")
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -44,7 +44,7 @@ Flags:
 			return types.Error{Msg: "Unable to create OpCap client."}
 		}
 		var packageManifestList pkgserverv1.PackageManifestList
-		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.CatalogSource, checkflags.FilterPackages)
+		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.CatalogSource, checkflags.Packages)
 		if err != nil {
 			return types.Error{Msg: "Unable to list PackageManifests.\n" + err.Error()}
 		}
@@ -68,7 +68,7 @@ Flags:
 			AuditPlan:              checkflags.AuditPlan,
 			CatalogSource:          checkflags.CatalogSource,
 			CatalogSourceNamespace: checkflags.CatalogSourceNamespace,
-			FilterPackages:         checkflags.FilterPackages,
+			Packages:               checkflags.Packages,
 		}
 
 		// run all dynamically built audits in the auditor workqueue
@@ -81,7 +81,7 @@ type CheckCommandFlags struct {
 	CatalogSource          string   `json:"catalogsource"`
 	CatalogSourceNamespace string   `json:"catalogsourcenamespace"`
 	ListPackages           bool     `json:"listPackages"`
-	FilterPackages         []string `json:"filterPackages"`
+	Packages               []string `json:"packages"`
 }
 
 var checkflags CheckCommandFlags
@@ -99,5 +99,5 @@ func init() {
 		"specifies the namespace where the catalogsource exists")
 	flags.StringSliceVar(&checkflags.AuditPlan, "auditplan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
 	flags.BoolVar(&checkflags.ListPackages, "list-packages", false, "list packages in the catalog")
-	flags.StringSliceVar(&checkflags.FilterPackages, "filter-packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
+	flags.StringSliceVar(&checkflags.Packages, "packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -63,7 +63,6 @@ Flags:
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-
 		capAuditor := &capability.CapAuditor{
 			AuditPlan:              checkflags.AuditPlan,
 			CatalogSource:          checkflags.CatalogSource,

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -10,58 +10,47 @@ import (
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
-// Audit defines all the methods used to run a full audit Plan against a single operator
-// All new capability tests should be added to this interface and used with a CapAudit
-// instance and as part of an auditPlan
-type Audit interface {
-	OperatorInstall() error
-	OperandInstall() error
-	OperandCleanUp() error
-	OperatorCleanUp() error
-	Report() error
-}
-
 // CapAudit is an implementation of the Audit interface
-type CapAudit struct {
+type capAudit struct {
 
 	// client has access to all operator methods
-	Client operator.Client
+	client operator.Client
 
 	// OpenShift Cluster Version under test
-	OcpVersion string
+	ocpVersion string
 
 	// namespace is the ns where the operator will be installed
-	Namespace string
+	namespace string
 
 	// operatorGroupData contains information to create operator groups
-	OperatorGroupData operator.OperatorGroupData
+	operatorGroupData operator.OperatorGroupData
 
 	// subscription holds the data to install an operator via OLM
-	Subscription operator.SubscriptionData
+	subscription operator.SubscriptionData
 
 	// Cluster CSV for current operator under test
-	Csv operatorv1alpha1.ClusterServiceVersion
+	csv operatorv1alpha1.ClusterServiceVersion
 
 	// How much time to wait for a CSV before timeout
-	CsvWaitTime time.Duration
+	csvWaitTime time.Duration
 
 	// If the given CSV timed out on install
-	CsvTimeout bool
+	csvTimeout bool
 
 	// auditPlan is a list of functions to be run in sequence in a given audit
 	// all of them must be an implemented method of CapAudit and must be part
 	// of the Audit interface
-	AuditPlan []string
+	auditPlan []string
 
 	// CustomResources stores CR manifests to deploy operands
-	CustomResources []map[string]interface{}
+	customResources []map[string]interface{}
 
 	// Operands stores a list of unstructured custom resources that were created at the API level
 	// This data is used for further analysis on statuses, conditions and other patterns
-	Operands []unstructured.Unstructured
+	operands []unstructured.Unstructured
 }
 
-func newCapAudit(c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (CapAudit, error) {
+func newCapAudit(c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (capAudit, error) {
 
 	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-")}, "-")
 	operatorGroupName := strings.Join([]string{subscription.Name, subscription.Channel, "group"}, "-")
@@ -69,18 +58,18 @@ func newCapAudit(c operator.Client, subscription operator.SubscriptionData, audi
 	ocpVersion, err := c.GetOpenShiftVersion()
 	if err != nil {
 		logger.Debugw("Couldn't get OpenShift version for testing", "Err:", err)
-		return CapAudit{}, err
+		return capAudit{}, err
 	}
 
-	return CapAudit{
-		Client:            c,
-		OcpVersion:        ocpVersion,
-		Namespace:         ns,
-		OperatorGroupData: newOperatorGroupData(operatorGroupName, getTargetNamespaces(subscription, ns)),
-		Subscription:      subscription,
-		CsvWaitTime:       time.Minute,
-		CsvTimeout:        false,
-		AuditPlan:         auditPlan,
+	return capAudit{
+		client:            c,
+		ocpVersion:        ocpVersion,
+		namespace:         ns,
+		operatorGroupData: newOperatorGroupData(operatorGroupName, getTargetNamespaces(subscription, ns)),
+		subscription:      subscription,
+		csvWaitTime:       time.Minute,
+		csvTimeout:        false,
+		auditPlan:         auditPlan,
 	}, nil
 }
 

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -63,8 +63,7 @@ type CapAudit struct {
 
 func newCapAudit(c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (CapAudit, error) {
 
-	// TODO: optimize performance by re-using the namespace for the same operator
-	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-"), strings.ToLower(string(subscription.InstallModeType))}, "-")
+	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-")}, "-")
 	operatorGroupName := strings.Join([]string{subscription.Name, subscription.Channel, "group"}, "-")
 
 	ocpVersion, err := c.GetOpenShiftVersion()

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -42,18 +42,18 @@ func (capAuditor *CapAuditor) buildWorkQueueByCatalog() error {
 	}
 
 	// Getting subscription data form the package manifests available in the selected catalog
-	s, err := c.GetSubscriptionData(capAuditor.CatalogSource, capAuditor.CatalogSourceNamespace, capAuditor.FilterPackages)
+	subscriptions, err := c.GetSubscriptionData(capAuditor.CatalogSource, capAuditor.CatalogSourceNamespace, capAuditor.FilterPackages)
 	if err != nil {
 		logger.Errorf("Error while getting bundles from CatalogSource %s: %w", capAuditor.CatalogSource, err)
 		return err
 	}
 
 	// build workqueue as buffered channel based subscriptionData list size
-	capAuditor.WorkQueue = make(chan capAudit, len(s))
+	capAuditor.WorkQueue = make(chan capAudit, len(subscriptions))
 	defer close(capAuditor.WorkQueue)
 
 	// add capAudits to the workqueue
-	for _, subscription := range s {
+	for _, subscription := range subscriptions {
 
 		capAudit, err := newCapAudit(c, subscription, capAuditor.AuditPlan)
 		if err != nil {

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -65,7 +65,8 @@ func (capAuditor *CapAuditor) buildWorkQueueByCatalog() error {
 func (capAuditor *CapAuditor) RunAudits() error {
 	err := capAuditor.buildWorkQueueByCatalog()
 	if err != nil {
-		logger.Fatalf("Unable to build workqueue err := %s", err.Error())
+		logger.Debugf("Unable to build workqueue err := %s", err.Error())
+		return err
 	}
 
 	// read workqueue for audits

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -24,8 +24,8 @@ type CapAuditor struct {
 	// CatalogSourceNamespace will be openshift-marketplace or custom
 	CatalogSourceNamespace string
 
-	// FilterPackages is a subset of packages to be tested from a catalogSource
-	FilterPackages []string
+	// Packages is a subset of packages to be tested from a catalogSource
+	Packages []string
 
 	// Workqueue holds capAudits in a buffered channel in order to execute them
 	WorkQueue chan capAudit
@@ -42,7 +42,7 @@ func (capAuditor *CapAuditor) buildWorkQueueByCatalog() error {
 	}
 
 	// Getting subscription data form the package manifests available in the selected catalog
-	subscriptions, err := c.GetSubscriptionData(capAuditor.CatalogSource, capAuditor.CatalogSourceNamespace, capAuditor.FilterPackages)
+	subscriptions, err := c.GetSubscriptionData(capAuditor.CatalogSource, capAuditor.CatalogSourceNamespace, capAuditor.Packages)
 	if err != nil {
 		logger.Errorf("Error while getting bundles from CatalogSource %s: %w", capAuditor.CatalogSource, err)
 		return err

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -20,7 +20,7 @@ type CapAuditor struct {
 	// Packages is a subset of packages to be tested from a catalogSource
 	Packages []string
 
-	// Workqueue holds capAudits in a buffered channel in order to execute them
+	// WorkQueue holds capAudits in a buffered channel in order to execute them
 	WorkQueue chan capAudit
 }
 

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -6,13 +6,6 @@ import (
 	"github.com/opdev/opcap/internal/operator"
 )
 
-// Auditor interface represents the object running capability audits against operators
-// It has methods to create a workqueue with all the package and audit requirements for a
-// particular audit run
-type Auditor interface {
-	RunAudits() error
-}
-
 // capAuditor implements Auditor
 type CapAuditor struct {
 

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -70,7 +70,6 @@ func (capAuditor *CapAuditor) buildWorkQueueByCatalog() error {
 
 // RunAudits executes all selected functions in order for a given audit at a time
 func (capAuditor *CapAuditor) RunAudits() error {
-
 	err := capAuditor.buildWorkQueueByCatalog()
 	if err != nil {
 		logger.Fatalf("Unable to build workqueue err := %s", err.Error())

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -2,7 +2,6 @@ package capability
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/opdev/opcap/internal/operator"
 
@@ -58,7 +57,7 @@ func (ca *capAudit) OperandCleanUp() error {
 				// delete the resource using the dynamic client
 				err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
 				if err != nil {
-					fmt.Printf("failed operandCleanUp: %s package: %s error: %s\n", Resource, ca.subscription.Package, err.Error())
+					logger.Debugf("failed operandCleanUp: %s package: %s error: %s\n", Resource, ca.subscription.Package, err.Error())
 					return err
 				}
 			}

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -14,11 +14,11 @@ import (
 )
 
 // OperandCleanup removes the operand from the OCP cluster in the ca.namespace
-func (ca *CapAudit) OperandCleanUp() error {
-	logger.Debugw("cleaningUp operand for operator", "package", ca.Subscription.Package, "channel", ca.Subscription.Channel, "installmode", ca.Subscription.InstallModeType)
+func (ca *capAudit) OperandCleanUp() error {
+	logger.Debugw("cleaningUp operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
 
-	if len(ca.CustomResources) > 0 {
-		for _, cr := range ca.CustomResources {
+	if len(ca.customResources) > 0 {
+		for _, cr := range ca.customResources {
 			obj := &unstructured.Unstructured{Object: cr}
 
 			// using dynamic client to create Unstructured objests in k8s
@@ -28,7 +28,7 @@ func (ca *CapAudit) OperandCleanUp() error {
 			}
 
 			var crdList apiextensionsv1.CustomResourceDefinitionList
-			err = ca.Client.ListCRDs(context.TODO(), &crdList)
+			err = ca.client.ListCRDs(context.TODO(), &crdList)
 			if err != nil {
 				return err
 			}
@@ -52,12 +52,12 @@ func (ca *CapAudit) OperandCleanUp() error {
 			name := obj.Object["metadata"].(map[string]interface{})["name"].(string)
 
 			// check if CR exists, only then cleanup the operand
-			crInstance, _ := client.Resource(gvr).Namespace(ca.Namespace).Get(context.TODO(), name, v1.GetOptions{})
+			crInstance, _ := client.Resource(gvr).Namespace(ca.namespace).Get(context.TODO(), name, v1.GetOptions{})
 			if crInstance != nil {
 				// delete the resource using the dynamic client
-				err = client.Resource(gvr).Namespace(ca.Namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
+				err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
 				if err != nil {
-					fmt.Printf("failed operandCleanUp: %s package: %s error: %s\n", Resource, ca.Subscription.Package, err.Error())
+					fmt.Printf("failed operandCleanUp: %s package: %s error: %s\n", Resource, ca.subscription.Package, err.Error())
 					return err
 				}
 			}

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -15,7 +15,8 @@ import (
 
 // OperandCleanup removes the operand from the OCP cluster in the ca.namespace
 func (ca *capAudit) OperandCleanUp() error {
-	logger.Debugw("cleaningUp operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
+	logger.Debugw("cleaningUp operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode",
+		ca.subscription.InstallModeType)
 
 	if len(ca.customResources) > 0 {
 		for _, cr := range ca.customResources {

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -95,9 +95,8 @@ func (ca *capAudit) OperandInstall() error {
 				if err != nil {
 
 					return err
-				} else {
-					ca.operands = append(ca.operands, *unstructuredCR)
 				}
+				ca.operands = append(ca.operands, *unstructuredCR)
 			} else {
 				logger.Debug("exiting OperandInstall since CSV has failed")
 			}

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -2,6 +2,7 @@ package capability
 
 import (
 	"context"
+	"os"
 	"strings"
 	"time"
 
@@ -105,7 +106,15 @@ func (ca *capAudit) OperandInstall() error {
 		logger.Debug("exiting OperandInstall since no ALM_Examples found in CSV")
 	}
 
-	ca.Report(OperandInstallRptOptionFile{FilePath: "operand_install_report.json"}, OperandInstallRptOptionPrint{})
+	file, err := os.OpenFile("operand_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		file.Close()
+		return err
+	}
+	defer file.Close()
+
+	ca.OperandInstallJsonReport(file)
+	ca.OperandTextReport(os.Stdout)
 
 	return nil
 }

--- a/internal/capability/operator_cleanup.go
+++ b/internal/capability/operator_cleanup.go
@@ -9,31 +9,27 @@ import (
 func (ca *capAudit) OperatorCleanUp() error {
 
 	// delete subscription
-	err := ca.client.DeleteSubscription(context.Background(), ca.subscription.Name, ca.namespace)
-	if err != nil {
+	if err := ca.client.DeleteSubscription(context.Background(), ca.subscription.Name, ca.namespace); err != nil {
 		logger.Debugf("Error while deleting Subscription: %w", err)
 		return err
 	}
 
 	// delete operator group
-	err = ca.client.DeleteOperatorGroup(context.Background(), ca.operatorGroupData.Name, ca.namespace)
-	if err != nil {
+	if err := ca.client.DeleteOperatorGroup(context.Background(), ca.operatorGroupData.Name, ca.namespace); err != nil {
 		logger.Debugf("Error while deleting OperatorGroup: %w", err)
 		return err
 	}
 
 	// delete target namespaces
 	for _, ns := range ca.operatorGroupData.TargetNamespaces {
-		err := operator.DeleteNamespace(context.Background(), ns)
-		if err != nil {
+		if err := operator.DeleteNamespace(context.Background(), ns); err != nil {
 			logger.Debugf("Error deleting target namespace %s", ns)
 			return err
 		}
 	}
 
 	// delete operator's own namespace
-	err = operator.DeleteNamespace(context.Background(), ca.namespace)
-	if err != nil {
+	if err := operator.DeleteNamespace(context.Background(), ca.namespace); err != nil {
 		logger.Debugf("Error deleting operator's own namespace %s", ca.namespace)
 		return err
 	}

--- a/internal/capability/operator_cleanup.go
+++ b/internal/capability/operator_cleanup.go
@@ -6,24 +6,24 @@ import (
 	"github.com/opdev/opcap/internal/operator"
 )
 
-func (ca *CapAudit) OperatorCleanUp() error {
+func (ca *capAudit) OperatorCleanUp() error {
 
 	// delete subscription
-	err := ca.Client.DeleteSubscription(context.Background(), ca.Subscription.Name, ca.Namespace)
+	err := ca.client.DeleteSubscription(context.Background(), ca.subscription.Name, ca.namespace)
 	if err != nil {
 		logger.Debugf("Error while deleting Subscription: %w", err)
 		return err
 	}
 
 	// delete operator group
-	err = ca.Client.DeleteOperatorGroup(context.Background(), ca.OperatorGroupData.Name, ca.Namespace)
+	err = ca.client.DeleteOperatorGroup(context.Background(), ca.operatorGroupData.Name, ca.namespace)
 	if err != nil {
 		logger.Debugf("Error while deleting OperatorGroup: %w", err)
 		return err
 	}
 
 	// delete target namespaces
-	for _, ns := range ca.OperatorGroupData.TargetNamespaces {
+	for _, ns := range ca.operatorGroupData.TargetNamespaces {
 		err := operator.DeleteNamespace(context.Background(), ns)
 		if err != nil {
 			logger.Debugf("Error deleting target namespace %s", ns)
@@ -32,9 +32,9 @@ func (ca *CapAudit) OperatorCleanUp() error {
 	}
 
 	// delete operator's own namespace
-	err = operator.DeleteNamespace(context.Background(), ca.Namespace)
+	err = operator.DeleteNamespace(context.Background(), ca.namespace)
 	if err != nil {
-		logger.Debugf("Error deleting operator's own namespace %s", ca.Namespace)
+		logger.Debugf("Error deleting operator's own namespace %s", ca.namespace)
 		return err
 	}
 	return nil

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -2,6 +2,7 @@ package capability
 
 import (
 	"context"
+	"os"
 
 	log "github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
@@ -46,7 +47,16 @@ func (ca *capAudit) OperatorInstall() error {
 		}
 	}
 
-	ca.Report(OperatorInstallRptOptionFile{FilePath: "operator_install_report.json"}, OperatorInstallRptOptionPrint{})
+	file, err := os.OpenFile("operator_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		file.Close()
+		return err
+	}
+	defer file.Close()
+
+	ca.OperatorInstallJsonReport(file)
+
+	ca.OperatorInstallTextReport(os.Stdout)
 
 	return nil
 }

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -13,7 +13,10 @@ func (ca *capAudit) OperatorInstall() error {
 	logger.Debugw("installing package", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
 
 	// create operator's own namespace
-	operator.CreateNamespace(context.Background(), ca.namespace)
+	_, err := operator.CreateNamespace(context.Background(), ca.namespace)
+	if err != nil {
+		return err
+	}
 
 	// create remaining target namespaces watched by the operator
 	for _, ns := range ca.operatorGroupData.TargetNamespaces {
@@ -26,7 +29,7 @@ func (ca *capAudit) OperatorInstall() error {
 	ca.client.CreateOperatorGroup(context.Background(), ca.operatorGroupData, ca.namespace)
 
 	// create subscription for operator package/channel
-	_, err := ca.client.CreateSubscription(context.Background(), ca.subscription, ca.namespace)
+	_, err = ca.client.CreateSubscription(context.Background(), ca.subscription, ca.namespace)
 	if err != nil {
 		logger.Debugf("Error creating subscriptions: %w", err)
 		return err

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -9,37 +9,37 @@ import (
 
 var logger = log.Sugar
 
-func (ca *CapAudit) OperatorInstall() error {
-	logger.Debugw("installing package", "package", ca.Subscription.Package, "channel", ca.Subscription.Channel, "installmode", ca.Subscription.InstallModeType)
+func (ca *capAudit) OperatorInstall() error {
+	logger.Debugw("installing package", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
 
 	// create operator's own namespace
-	operator.CreateNamespace(context.Background(), ca.Namespace)
+	operator.CreateNamespace(context.Background(), ca.namespace)
 
 	// create remaining target namespaces watched by the operator
-	for _, ns := range ca.OperatorGroupData.TargetNamespaces {
-		if ns != ca.Namespace {
+	for _, ns := range ca.operatorGroupData.TargetNamespaces {
+		if ns != ca.namespace {
 			operator.CreateNamespace(context.Background(), ns)
 		}
 	}
 
 	// create operator group for operator package/channel
-	ca.Client.CreateOperatorGroup(context.Background(), ca.OperatorGroupData, ca.Namespace)
+	ca.client.CreateOperatorGroup(context.Background(), ca.operatorGroupData, ca.namespace)
 
 	// create subscription for operator package/channel
-	_, err := ca.Client.CreateSubscription(context.Background(), ca.Subscription, ca.Namespace)
+	_, err := ca.client.CreateSubscription(context.Background(), ca.subscription, ca.namespace)
 	if err != nil {
 		logger.Debugf("Error creating subscriptions: %w", err)
 		return err
 	}
 
 	// Get a Succeeded or Failed CSV with one minute timeout
-	ca.Csv, err = ca.Client.GetCompletedCsvWithTimeout(ca.Namespace, ca.CsvWaitTime)
+	ca.csv, err = ca.client.GetCompletedCsvWithTimeout(ca.namespace, ca.csvWaitTime)
 
 	if err != nil {
 
 		// If error is timeout than don't log phase but timeout
 		if err.Error() == "operator install timeout" {
-			ca.CsvTimeout = true
+			ca.csvTimeout = true
 		} else {
 			return err
 		}

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -13,8 +13,7 @@ func (ca *capAudit) OperatorInstall() error {
 	logger.Debugw("installing package", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
 
 	// create operator's own namespace
-	_, err := operator.CreateNamespace(context.Background(), ca.namespace)
-	if err != nil {
+	if _, err := operator.CreateNamespace(context.Background(), ca.namespace); err != nil {
 		return err
 	}
 
@@ -29,17 +28,16 @@ func (ca *capAudit) OperatorInstall() error {
 	ca.client.CreateOperatorGroup(context.Background(), ca.operatorGroupData, ca.namespace)
 
 	// create subscription for operator package/channel
-	_, err = ca.client.CreateSubscription(context.Background(), ca.subscription, ca.namespace)
-	if err != nil {
+	if _, err := ca.client.CreateSubscription(context.Background(), ca.subscription, ca.namespace); err != nil {
 		logger.Debugf("Error creating subscriptions: %w", err)
 		return err
 	}
 
 	// Get a Succeeded or Failed CSV with one minute timeout
+	var err error
 	ca.csv, err = ca.client.GetCompletedCsvWithTimeout(ca.namespace, ca.csvWaitTime)
 
 	if err != nil {
-
 		// If error is timeout than don't log phase but timeout
 		if err.Error() == "operator install timeout" {
 			ca.csvTimeout = true

--- a/internal/capability/report.go
+++ b/internal/capability/report.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func (ca CapAudit) Report(opts ...ReportOption) error {
+func (ca capAudit) Report(opts ...ReportOption) error {
 
 	for _, opt := range opts {
 
@@ -22,32 +22,32 @@ func (ca CapAudit) Report(opts ...ReportOption) error {
 }
 
 type ReportOption interface {
-	report(ca CapAudit) error
+	report(ca capAudit) error
 }
 
 // Simple print option implmentation for operator install
 type OperatorInstallRptOptionPrint struct{}
 
-func (OperatorInstallRptOptionPrint) report(ca CapAudit) error {
+func (OperatorInstallRptOptionPrint) report(ca capAudit) error {
 
 	fmt.Println()
 	fmt.Println("Operator Install Report:")
 	fmt.Println("-----------------------------------------")
 	fmt.Printf("Report Date: %s\n", time.Now())
-	fmt.Printf("OpenShift Version: %s\n", ca.OcpVersion)
-	fmt.Printf("Package Name: %s\n", ca.Subscription.Package)
-	fmt.Printf("Channel: %s\n", ca.Subscription.Channel)
-	fmt.Printf("Catalog Source: %s\n", ca.Subscription.CatalogSource)
-	fmt.Printf("Install Mode: %s\n", ca.Subscription.InstallModeType)
+	fmt.Printf("OpenShift Version: %s\n", ca.ocpVersion)
+	fmt.Printf("Package Name: %s\n", ca.subscription.Package)
+	fmt.Printf("Channel: %s\n", ca.subscription.Channel)
+	fmt.Printf("Catalog Source: %s\n", ca.subscription.CatalogSource)
+	fmt.Printf("Install Mode: %s\n", ca.subscription.InstallModeType)
 
-	if !ca.CsvTimeout {
-		fmt.Printf("Result: %s\n", ca.Csv.Status.Phase)
+	if !ca.csvTimeout {
+		fmt.Printf("Result: %s\n", ca.csv.Status.Phase)
 	} else {
 		fmt.Println("Result: timeout")
 	}
 
-	fmt.Printf("Message: %s\n", ca.Csv.Status.Message)
-	fmt.Printf("Reason: %s\n", ca.Csv.Status.Reason)
+	fmt.Printf("Message: %s\n", ca.csv.Status.Message)
+	fmt.Printf("Reason: %s\n", ca.csv.Status.Reason)
 	fmt.Println("-----------------------------------------")
 
 	return nil
@@ -58,7 +58,7 @@ type OperatorInstallRptOptionFile struct {
 	FilePath string
 }
 
-func (opt OperatorInstallRptOptionFile) report(ca CapAudit) error {
+func (opt OperatorInstallRptOptionFile) report(ca capAudit) error {
 
 	file, err := os.OpenFile(opt.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
 	if err != nil {
@@ -67,12 +67,12 @@ func (opt OperatorInstallRptOptionFile) report(ca CapAudit) error {
 	}
 	defer file.Close()
 
-	if !ca.CsvTimeout {
+	if !ca.csvTimeout {
 
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + string(ca.Csv.Status.Phase) + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\"}\n")
+		file.WriteString("{\"level\":\"info\",\"message\":\"" + string(ca.csv.Status.Phase) + "\",\"package\":\"" + ca.subscription.Package + "\",\"channel\":\"" + ca.subscription.Channel + "\",\"installmode\":\"" + string(ca.subscription.InstallModeType) + "\"}\n")
 	} else {
 
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + "timeout" + "\",\"package\":\"" + ca.Subscription.Package + "\",\"channel\":\"" + ca.Subscription.Channel + "\",\"installmode\":\"" + string(ca.Subscription.InstallModeType) + "\"}\n")
+		file.WriteString("{\"level\":\"info\",\"message\":\"" + "timeout" + "\",\"package\":\"" + ca.subscription.Package + "\",\"channel\":\"" + ca.subscription.Channel + "\",\"installmode\":\"" + string(ca.subscription.InstallModeType) + "\"}\n")
 	}
 
 	return nil
@@ -81,21 +81,21 @@ func (opt OperatorInstallRptOptionFile) report(ca CapAudit) error {
 // Simple print option implmentation for operand install
 type OperandInstallRptOptionPrint struct{}
 
-func (OperandInstallRptOptionPrint) report(ca CapAudit) error {
+func (OperandInstallRptOptionPrint) report(ca capAudit) error {
 
-	for _, cr := range ca.CustomResources {
+	for _, cr := range ca.customResources {
 		operand := &unstructured.Unstructured{Object: cr}
 
 		fmt.Println()
 		fmt.Println("Operand Install Report:")
 		fmt.Println("-----------------------------------------")
 		fmt.Printf("Report Date: %s\n", time.Now())
-		fmt.Printf("OpenShift Version: %s\n", ca.OcpVersion)
-		fmt.Printf("Package Name: %s\n", ca.Subscription.Package)
+		fmt.Printf("OpenShift Version: %s\n", ca.ocpVersion)
+		fmt.Printf("Package Name: %s\n", ca.subscription.Package)
 		fmt.Printf("Operand Kind: %s\n", operand.GetKind())
 		fmt.Printf("Operand Name: %s\n", operand.GetName())
 
-		if len(ca.Operands) > 0 {
+		if len(ca.operands) > 0 {
 			fmt.Println("Operand Creation: Succeeded")
 		} else {
 			fmt.Println("Operand Creation: Failed")
@@ -110,9 +110,9 @@ type OperandInstallRptOptionFile struct {
 	FilePath string
 }
 
-func (opt OperandInstallRptOptionFile) report(ca CapAudit) error {
+func (opt OperandInstallRptOptionFile) report(ca capAudit) error {
 
-	for _, cr := range ca.CustomResources {
+	for _, cr := range ca.customResources {
 		operand := &unstructured.Unstructured{Object: cr}
 
 		file, err := os.OpenFile(opt.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
@@ -122,12 +122,12 @@ func (opt OperandInstallRptOptionFile) report(ca CapAudit) error {
 		}
 		defer file.Close()
 
-		if len(ca.Operands) > 0 {
+		if len(ca.operands) > 0 {
 
-			file.WriteString("{\"package\":\"" + ca.Subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "created" + "\"}\n")
+			file.WriteString("{\"package\":\"" + ca.subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "created" + "\"}\n")
 		} else {
 
-			file.WriteString("{\"package\":\"" + ca.Subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "failed" + "\"}\n")
+			file.WriteString("{\"package\":\"" + ca.subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "failed" + "\"}\n")
 		}
 	}
 

--- a/internal/capability/report.go
+++ b/internal/capability/report.go
@@ -2,132 +2,88 @@ package capability
 
 import (
 	"fmt"
-	"os"
+	"io"
+
 	"time"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func (ca capAudit) Report(opts ...ReportOption) error {
+func (ca capAudit) OperatorInstallTextReport(w io.Writer) error {
 
-	for _, opt := range opts {
-
-		err := opt.report(ca)
-		if err != nil {
-			logger.Debugf("Unable to generate report for %T", opt, "Error: %s", err)
-		}
-
-	}
-	return nil
-}
-
-type ReportOption interface {
-	report(ca capAudit) error
-}
-
-// Simple print option implmentation for operator install
-type OperatorInstallRptOptionPrint struct{}
-
-func (OperatorInstallRptOptionPrint) report(ca capAudit) error {
-
-	fmt.Println()
-	fmt.Println("Operator Install Report:")
-	fmt.Println("-----------------------------------------")
-	fmt.Printf("Report Date: %s\n", time.Now())
-	fmt.Printf("OpenShift Version: %s\n", ca.ocpVersion)
-	fmt.Printf("Package Name: %s\n", ca.subscription.Package)
-	fmt.Printf("Channel: %s\n", ca.subscription.Channel)
-	fmt.Printf("Catalog Source: %s\n", ca.subscription.CatalogSource)
-	fmt.Printf("Install Mode: %s\n", ca.subscription.InstallModeType)
+	fmt.Fprint(w, "\n")
+	fmt.Fprint(w, "Operator Install Report:\n")
+	fmt.Fprint(w, "-----------------------------------------\n")
+	fmt.Fprintf(w, "Report Date: %s\n", time.Now())
+	fmt.Fprintf(w, "OpenShift Version: %s\n", ca.ocpVersion)
+	fmt.Fprintf(w, "Package Name: %s\n", ca.subscription.Package)
+	fmt.Fprintf(w, "Channel: %s\n", ca.subscription.Channel)
+	fmt.Fprintf(w, "Catalog Source: %s\n", ca.subscription.CatalogSource)
+	fmt.Fprintf(w, "Install Mode: %s\n", ca.subscription.InstallModeType)
 
 	if !ca.csvTimeout {
-		fmt.Printf("Result: %s\n", ca.csv.Status.Phase)
+		fmt.Fprintf(w, "Result: %s\n", ca.csv.Status.Phase)
 	} else {
-		fmt.Println("Result: timeout")
+		fmt.Fprint(w, "Result: timeout\n")
 	}
 
-	fmt.Printf("Message: %s\n", ca.csv.Status.Message)
-	fmt.Printf("Reason: %s\n", ca.csv.Status.Reason)
-	fmt.Println("-----------------------------------------")
+	fmt.Fprintf(w, "Message: %s\n", ca.csv.Status.Message)
+	fmt.Fprintf(w, "Reason: %s\n", ca.csv.Status.Reason)
+	fmt.Fprint(w, "-----------------------------------------\n")
 
 	return nil
 }
 
-// Simple file option implementation for operator install
-type OperatorInstallRptOptionFile struct {
-	FilePath string
-}
-
-func (opt OperatorInstallRptOptionFile) report(ca capAudit) error {
-
-	file, err := os.OpenFile(opt.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		file.Close()
-		return err
-	}
-	defer file.Close()
+func (ca capAudit) OperatorInstallJsonReport(w io.Writer) error {
 
 	if !ca.csvTimeout {
-
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + string(ca.csv.Status.Phase) + "\",\"package\":\"" + ca.subscription.Package + "\",\"channel\":\"" + ca.subscription.Channel + "\",\"installmode\":\"" + string(ca.subscription.InstallModeType) + "\"}\n")
+		fmt.Fprintf(w, "{\"level\":\"info\",\"message\":\""+string(ca.csv.Status.Phase)+"\",\"package\":\""+ca.subscription.Package+
+			"\",\"channel\":\""+ca.subscription.Channel+"\",\"installmode\":\""+string(ca.subscription.InstallModeType)+"\"}\n")
 	} else {
-
-		file.WriteString("{\"level\":\"info\",\"message\":\"" + "timeout" + "\",\"package\":\"" + ca.subscription.Package + "\",\"channel\":\"" + ca.subscription.Channel + "\",\"installmode\":\"" + string(ca.subscription.InstallModeType) + "\"}\n")
+		fmt.Fprintf(w, "{\"level\":\"info\",\"message\":\""+"timeout"+"\",\"package\":\""+ca.subscription.Package+"\",\"channel\":\""+
+			ca.subscription.Channel+"\",\"installmode\":\""+string(ca.subscription.InstallModeType)+"\"}\n")
 	}
 
 	return nil
 }
 
-// Simple print option implmentation for operand install
-type OperandInstallRptOptionPrint struct{}
-
-func (OperandInstallRptOptionPrint) report(ca capAudit) error {
+func (ca capAudit) OperandTextReport(w io.Writer) error {
 
 	for _, cr := range ca.customResources {
 		operand := &unstructured.Unstructured{Object: cr}
 
-		fmt.Println()
-		fmt.Println("Operand Install Report:")
-		fmt.Println("-----------------------------------------")
-		fmt.Printf("Report Date: %s\n", time.Now())
-		fmt.Printf("OpenShift Version: %s\n", ca.ocpVersion)
-		fmt.Printf("Package Name: %s\n", ca.subscription.Package)
-		fmt.Printf("Operand Kind: %s\n", operand.GetKind())
-		fmt.Printf("Operand Name: %s\n", operand.GetName())
+		fmt.Fprint(w, "\n")
+		fmt.Fprintf(w, "Operand Install Report:\n")
+		fmt.Fprintf(w, "-----------------------------------------\n")
+		fmt.Fprintf(w, "Report Date: %s\n", time.Now())
+		fmt.Fprintf(w, "OpenShift Version: %s\n", ca.ocpVersion)
+		fmt.Fprintf(w, "Package Name: %s\n", ca.subscription.Package)
+		fmt.Fprintf(w, "Operand Kind: %s\n", operand.GetKind())
+		fmt.Fprintf(w, "Operand Name: %s\n", operand.GetName())
 
 		if len(ca.operands) > 0 {
-			fmt.Println("Operand Creation: Succeeded")
+			fmt.Fprint(w, "Operand Creation: Succeeded\n")
 		} else {
-			fmt.Println("Operand Creation: Failed")
+			fmt.Fprint(w, "Operand Creation: Failed\n")
 		}
-		fmt.Println("-----------------------------------------")
+		fmt.Fprint(w, "-----------------------------------------\n")
 	}
 	return nil
 }
 
-// Simple file option implementation for operand install
-type OperandInstallRptOptionFile struct {
-	FilePath string
-}
-
-func (opt OperandInstallRptOptionFile) report(ca capAudit) error {
+func (ca capAudit) OperandInstallJsonReport(w io.Writer) error {
 
 	for _, cr := range ca.customResources {
 		operand := &unstructured.Unstructured{Object: cr}
 
-		file, err := os.OpenFile(opt.FilePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-		if err != nil {
-			file.Close()
-			return err
-		}
-		defer file.Close()
-
 		if len(ca.operands) > 0 {
 
-			file.WriteString("{\"package\":\"" + ca.subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "created" + "\"}\n")
+			fmt.Fprintf(w, "{\"package\":\""+ca.subscription.Package+"\", \"Operand Kind\": \""+operand.GetKind()+"\", \"Operand Name\": \""+operand.GetName()+
+				"\",\"message\":\""+"created"+"\"}\n")
 		} else {
 
-			file.WriteString("{\"package\":\"" + ca.subscription.Package + "\", \"Operand Kind\": \"" + operand.GetKind() + "\", \"Operand Name\": \"" + operand.GetName() + "\",\"message\":\"" + "failed" + "\"}\n")
+			fmt.Fprintf(w, "{\"package\":\""+ca.subscription.Package+"\", \"Operand Kind\": \""+operand.GetKind()+"\", \"Operand Name\": \""+operand.GetName()+
+				"\",\"message\":\""+"failed"+"\"}\n")
 		}
 	}
 

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -34,31 +34,13 @@ type Client interface {
 	DeleteSubscription(ctx context.Context, name string, namespace string) error
 	GetCompletedCsvWithTimeout(namespace string, delay time.Duration) (operatorv1alpha1.ClusterServiceVersion, error)
 	GetOpenShiftVersion() (string, error)
-	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, opts OperatorCheckOptions) error
-	GetSubscriptionData(options OperatorCheckOptions) ([]SubscriptionData, error)
+	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, catalogSource string, filter []string) error
+	GetSubscriptionData(source string, namespace string, filter []string) ([]SubscriptionData, error)
 	ListCRDs(ctx context.Context, list *apiextensionsv1.CustomResourceDefinitionList) error
 }
 
 type operatorClient struct {
 	Client runtimeClient.Client
-}
-
-type OperatorCheckOptions struct {
-	// AuditPlan is an ordered list of tests to be run
-	// during an operator audit
-	AuditPlan []string
-	// CatalogSource provides target catalog source
-	// from which to list package manifests
-	CatalogSource string
-	// CatalogSourceNamespace specifies the namespace of the
-	// catalog source to be used
-	CatalogSourceNamespace string
-	// ListPackages operation lists packages in the catalog source
-	ListPackages bool
-	// FilterPackages provides a list of packages to find
-	FilterPackages []string
-	// AllInstallModes is passed to test all install modes
-	AllInstallModes bool
 }
 
 func NewOpCapClient() (Client, error) {


### PR DESCRIPTION
This refactor is supposed to revert the potential risk for redundant circular reference caused by importing from operator package options or flags that belong to the command level. At the same time avoid the risk of having a tight coupling trying to pass all options to the operator package that doesn't care about most of them. 

Now new functionality like adding CRs from the command line are very hard to implement. It's definitely a no go having to change the package on the bottom of the stack to implement a new flag that will be used on middle of the stack.

The flow of opcap packages is designed to be `check` --> consumes --> `capability` --> that consumes --> `operator`. It is still not perfect. But we should avoid as much as possible trying to pass parameters across the packages to the bottom of the stack or importing in reverse order which may lead to circular reference when we need to add new functionality in the future. 

I've also took the opportunity to eliminate some unnecessary code a make the interfaces mode clear by not exporting a bunch of things that were unnecessarily exported on the capability package.

Here is what's being removed from the operator package:

```
type OperatorCheckOptions struct {
	// AuditPlan is an ordered list of tests to be run
	// during an operator audit
	AuditPlan []string
	// CatalogSource provides target catalog source
	// from which to list package manifests
	CatalogSource string
	// CatalogSourceNamespace specifies the namespace of the
	// catalog source to be used
	CatalogSourceNamespace string
	// ListPackages operation lists packages in the catalog source
	ListPackages bool
	// FilterPackages provides a list of packages to find
	FilterPackages []string
	// AllInstallModes is passed to test all install modes
	AllInstallModes bool
}
```
The flags should be processed on the top of the stack and not on the bottom.

We still need to redo the all install mode strategy though.