### PR TITLE
Adding Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,29 @@
+<!--Please provide a short description of the contents of your PR with instructions
+for testing if necessary-->
+## Description of PR
+
+<!--All PRs required a linked issue. If there is not an issue for your PR, please
+create one with a detailed description of the problem you are solving before you
+create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
+Fixes #101
+
+<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
+## Changes (required)
+
+- Item 1
+- Item 2
+
+<!--Please list any items deprecated by your PR. Feel free to remove this section if unused.-->
+## Deprecations (optional)
+
+<!--Please ensure you have completed the following tasks prior to review-->
+## Checklist (required)
+- [ ] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation if needed
+- [ ] I have checked that my changes pass all tests
+
+<!--Please list any external references that might be helpful in understanding your changes.
+Feel free to remove this section if unused.-->
+## References (optional)


### PR DESCRIPTION
Pull request template added for the github repo which lists out all our
required bits of information for new PRs, as well as requiring linked
issues and a checklist of tasks and a link to the contribution
guidelines.

Addresses #181