### PR TITLE
Support all-installmodes tests for an operator

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -60,6 +60,7 @@ and/or users.`,
 			CatalogSource:          checkflags.CatalogSource,
 			CatalogSourceNamespace: checkflags.CatalogSourceNamespace,
 			Packages:               checkflags.Packages,
+			AllInstallModes:        checkflags.AllInstallModes,
 		}
 
 		// run all dynamically built audits in the auditor workqueue
@@ -73,6 +74,7 @@ type CheckCommandFlags struct {
 	CatalogSourceNamespace string   `json:"catalogsourcenamespace"`
 	ListPackages           bool     `json:"listPackages"`
 	Packages               []string `json:"packages"`
+	AllInstallModes        bool     `json:"allInstallModes"`
 }
 
 var checkflags CheckCommandFlags
@@ -90,4 +92,5 @@ func init() {
 	flags.StringSliceVar(&checkflags.AuditPlan, "audit-plan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
 	flags.BoolVar(&checkflags.ListPackages, "list-packages", false, "list packages in the catalog")
 	flags.StringSliceVar(&checkflags.Packages, "packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
+	flags.BoolVar(&checkflags.AllInstallModes, "all-installmodes", false, "when set, all install modes supported by an operator will be tested")
 }

--- a/internal/operator/subscription.go
+++ b/internal/operator/subscription.go
@@ -47,19 +47,17 @@ func (c operatorClient) GetSubscriptionData(catalogSource string, catalogSourceN
 				if !installMode.Supported {
 					continue
 				}
-
-				s := SubscriptionData{
-					Name:                   strings.Join([]string{pkgch.Name, pkgm.Name, "subscription"}, "-"),
-					Channel:                pkgch.Name,
-					CatalogSource:          catalogSource,
-					CatalogSourceNamespace: catalogSourceNamespace,
-					Package:                pkgm.Name,
-					InstallModeType:        installMode.Type,
-					InstallPlanApproval:    operatorv1alpha1.ApprovalAutomatic,
-				}
-
-				SubscriptionList = append(SubscriptionList, s)
-				break
+				SubscriptionList = append(SubscriptionList,
+					SubscriptionData{
+						Name:                   strings.Join([]string{pkgch.Name, pkgm.Name, strings.ToLower(string(installMode.Type)), "subscription"}, "-"),
+						Channel:                pkgch.Name,
+						CatalogSource:          catalogSource,
+						CatalogSourceNamespace: catalogSourceNamespace,
+						Package:                pkgm.Name,
+						InstallModeType:        installMode.Type,
+						InstallPlanApproval:    operatorv1alpha1.ApprovalAutomatic,
+					},
+				)
 			}
 		}
 	}


### PR DESCRIPTION
## Description of PR
This commit allows the testing of all install modes that are supported
by an operator.
Fixes #189.

## Changes (required)

- [add all-install modes flag to check command](https://github.com/opdev/opcap/commit/222300d71a5871dcb6db46c825c04500ab329812)
- [add all install mode types to SubscriptionList](https://github.com/opdev/opcap/commit/de280cf71c6a1264c7c07664101f8b5abf1ef7ee)
- [add logic to the auditor to support testing all install modes by an operator](https://github.com/opdev/opcap/commit/409dc97f82b1694ed92607ced49351d814dce15e)
- [change ns name to resolve creation conflicts](https://github.com/opdev/opcap/pull/196/commits/cc9988f5220dfe1651af41d9d9620d19a23c802c)

## Checklist (required)

- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests

## Results:
Command:
```
./bin/opcap check --packages=cloud-native-postgresql --all-installmodes=true --audit-plan=OperatorInstall,OperandInstall,OperandCleanUp,OperatorCleanUp
```

Output of `operator_install_report.json`
```
{"level":"info","message":"Succeeded","package":"cloud-native-postgresql","channel":"stable-v1.16","installmode":"OwnNamespace"}
{"level":"info","message":"Succeeded","package":"cloud-native-postgresql","channel":"stable-v1.16","installmode":"SingleNamespace"}
{"level":"info","message":"Succeeded","package":"cloud-native-postgresql","channel":"stable-v1.16","installmode":"MultiNamespace"}
{"level":"info","message":"Succeeded","package":"cloud-native-postgresql","channel":"stable-v1.16","installmode":"AllNamespaces"}
```

Signed-off-by: Yash Oza <yoza@redhat.com>