### PR TITLE
Remove redundant text from check cmd description

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -18,28 +18,13 @@ import (
 
 // TODO: provide godoc compatible comment for checkCmd
 var checkCmd = &cobra.Command{
-	Use: "check",
-	// TODO: provide Short description for check command
+	Use:   "check",
 	Short: "Checks if operator meets minimum capability requirement.",
-	// TODO: provide Long description for check command
 	Long: `The 'check' command checks if OpenShift operators meet minimum
 requirements for Operator Capabilities Level to attest operator
 advanced features by running custom resources provided by CSVs
-and/or users.
-
-Usage:
-opcap check [flags]
-
-Example:
-opcap check --catalogsource=certified-operators --catalogsourcenamespace=openshift-marketplace --list-packages=false'
-
-Flags:
---catalogsource				specifies the catalogsource to test against
---catalogsourcenamespace	specifies the namespace where the catalogsource exists
---auditplan					audit plan is the ordered list of operator test functions to be called during a capability audit
---list-packages				list packages in the catalog
---filter-packages			a list of package(s) which limits audits and/or other flag(s) output
-`,
+and/or users.`,
+	Example: "opcap check --catalogsource=certified-operators --catalogsourcenamespace=openshift-marketplace",
 	PreRunE: func(cmd *cobra.Command, args []string) error {
 		psc, err := operator.NewOpCapClient()
 		if err != nil {
@@ -93,8 +78,7 @@ type CheckCommandFlags struct {
 var checkflags CheckCommandFlags
 
 func init() {
-
-	var defaultAuditPlan = []string{"OperatorInstall", "OperatorCleanUp"}
+	defaultAuditPlan := []string{"OperatorInstall", "OperatorCleanUp"}
 
 	rootCmd.AddCommand(checkCmd)
 	flags := checkCmd.Flags()


### PR DESCRIPTION
The flags and examples are automatically generated. There is no need to maintain the extra text.

Fixes #201

Signed-off-by: Brad P. Crochet <brad@redhat.com>
