### PR TITLE
ioutil is deprecated

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strconv"
 	"time"
@@ -157,7 +156,7 @@ func uploadRunE(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err = ioutil.WriteFile("report.json", data, 0o644); err != nil {
+	if err = os.WriteFile("report.json", data, 0o644); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Upload uses ioutil.WriteFile. ioutil has been deprecated since 1.16. Move to using os.WriteFile instead.

Signed-off-by: Brad P. Crochet <brad@redhat.com>
