### PR TITLE
Pass the same context throughout the stack

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 	"go/types"
 	"os"
@@ -31,7 +30,7 @@ and/or users.`,
 			return types.Error{Msg: "Unable to create OpCap client."}
 		}
 		var packageManifestList pkgserverv1.PackageManifestList
-		err = psc.ListPackageManifests(context.TODO(), &packageManifestList, checkflags.CatalogSource, checkflags.Packages)
+		err = psc.ListPackageManifests(cmd.Context(), &packageManifestList, checkflags.CatalogSource, checkflags.Packages)
 		if err != nil {
 			return types.Error{Msg: "Unable to list PackageManifests.\n" + err.Error()}
 		}
@@ -64,7 +63,7 @@ and/or users.`,
 		}
 
 		// run all dynamically built audits in the auditor workqueue
-		capAuditor.RunAudits()
+		capAuditor.RunAudits(cmd.Context())
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -25,9 +26,9 @@ to quickly create a Cobra application.`,
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
+	err := rootCmd.ExecuteContext(context.Background())
 	if err != nil {
-		fmt.Fprintln(os.Stderr, "Opcap tool execution failed: ", err)
+		fmt.Fprintf(rootCmd.ErrOrStderr(), "Opcap tool execution failed: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -90,7 +90,7 @@ func uploadPreRunE(cmd *cobra.Command, args []string) error {
 		os.Exit(1)
 	}
 
-	osversion, err = opClient.GetOpenShiftVersion()
+	osversion, err = opClient.GetOpenShiftVersion(cmd.Context())
 	if err != nil {
 		fmt.Fprintln(os.Stderr, "Failed to connect to OpenShift: ", err)
 		os.Exit(1)
@@ -117,7 +117,7 @@ func uploadRunE(cmd *cobra.Command, args []string) error {
 		minioClient.TraceOn(os.Stdout)
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(cmd.Context())
 	defer cancel()
 
 	// check for bucket, create if it does not exist

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -1,6 +1,7 @@
 package capability
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -49,11 +50,11 @@ type capAudit struct {
 	operands []unstructured.Unstructured
 }
 
-func newCapAudit(c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (capAudit, error) {
+func newCapAudit(ctx context.Context, c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (capAudit, error) {
 	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-")}, "-")
 	operatorGroupName := strings.Join([]string{subscription.Name, subscription.Channel, "group"}, "-")
 
-	ocpVersion, err := c.GetOpenShiftVersion()
+	ocpVersion, err := c.GetOpenShiftVersion(ctx)
 	if err != nil {
 		logger.Debugw("Couldn't get OpenShift version for testing", "Err:", err)
 		return capAudit{}, err

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -13,7 +13,7 @@ import (
 )
 
 // OperandCleanup removes the operand from the OCP cluster in the ca.namespace
-func (ca *capAudit) OperandCleanUp() error {
+func (ca *capAudit) OperandCleanUp(ctx context.Context) error {
 	logger.Debugw("cleaningUp operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode",
 		ca.subscription.InstallModeType)
 
@@ -28,7 +28,7 @@ func (ca *capAudit) OperandCleanUp() error {
 			}
 
 			var crdList apiextensionsv1.CustomResourceDefinitionList
-			err = ca.client.ListCRDs(context.TODO(), &crdList)
+			err = ca.client.ListCRDs(ctx, &crdList)
 			if err != nil {
 				return err
 			}
@@ -52,10 +52,10 @@ func (ca *capAudit) OperandCleanUp() error {
 			name := obj.Object["metadata"].(map[string]interface{})["name"].(string)
 
 			// check if CR exists, only then cleanup the operand
-			crInstance, _ := client.Resource(gvr).Namespace(ca.namespace).Get(context.TODO(), name, v1.GetOptions{})
+			crInstance, _ := client.Resource(gvr).Namespace(ca.namespace).Get(ctx, name, v1.GetOptions{})
 			if crInstance != nil {
 				// delete the resource using the dynamic client
-				err = client.Resource(gvr).Namespace(ca.namespace).Delete(context.TODO(), name, v1.DeleteOptions{})
+				err = client.Resource(gvr).Namespace(ca.namespace).Delete(ctx, name, v1.DeleteOptions{})
 				if err != nil {
 					logger.Debugf("failed operandCleanUp: %s package: %s error: %s\n", Resource, ca.subscription.Package, err.Error())
 					return err

--- a/internal/capability/operator_cleanup.go
+++ b/internal/capability/operator_cleanup.go
@@ -6,29 +6,29 @@ import (
 	"github.com/opdev/opcap/internal/operator"
 )
 
-func (ca *capAudit) OperatorCleanUp() error {
+func (ca *capAudit) OperatorCleanUp(ctx context.Context) error {
 	// delete subscription
-	if err := ca.client.DeleteSubscription(context.Background(), ca.subscription.Name, ca.namespace); err != nil {
+	if err := ca.client.DeleteSubscription(ctx, ca.subscription.Name, ca.namespace); err != nil {
 		logger.Debugf("Error while deleting Subscription: %w", err)
 		return err
 	}
 
 	// delete operator group
-	if err := ca.client.DeleteOperatorGroup(context.Background(), ca.operatorGroupData.Name, ca.namespace); err != nil {
+	if err := ca.client.DeleteOperatorGroup(ctx, ca.operatorGroupData.Name, ca.namespace); err != nil {
 		logger.Debugf("Error while deleting OperatorGroup: %w", err)
 		return err
 	}
 
 	// delete target namespaces
 	for _, ns := range ca.operatorGroupData.TargetNamespaces {
-		if err := operator.DeleteNamespace(context.Background(), ns); err != nil {
+		if err := operator.DeleteNamespace(ctx, ns); err != nil {
 			logger.Debugf("Error deleting target namespace %s", ns)
 			return err
 		}
 	}
 
 	// delete operator's own namespace
-	if err := operator.DeleteNamespace(context.Background(), ca.namespace); err != nil {
+	if err := operator.DeleteNamespace(ctx, ca.namespace); err != nil {
 		logger.Debugf("Error deleting operator's own namespace %s", ca.namespace)
 		return err
 	}

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -10,33 +10,33 @@ import (
 
 var logger = log.Sugar
 
-func (ca *capAudit) OperatorInstall() error {
+func (ca *capAudit) OperatorInstall(ctx context.Context) error {
 	logger.Debugw("installing package", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
 
 	// create operator's own namespace
-	if _, err := operator.CreateNamespace(context.Background(), ca.namespace); err != nil {
+	if _, err := operator.CreateNamespace(ctx, ca.namespace); err != nil {
 		return err
 	}
 
 	// create remaining target namespaces watched by the operator
 	for _, ns := range ca.operatorGroupData.TargetNamespaces {
 		if ns != ca.namespace {
-			operator.CreateNamespace(context.Background(), ns)
+			operator.CreateNamespace(ctx, ns)
 		}
 	}
 
 	// create operator group for operator package/channel
-	ca.client.CreateOperatorGroup(context.Background(), ca.operatorGroupData, ca.namespace)
+	ca.client.CreateOperatorGroup(ctx, ca.operatorGroupData, ca.namespace)
 
 	// create subscription for operator package/channel
-	if _, err := ca.client.CreateSubscription(context.Background(), ca.subscription, ca.namespace); err != nil {
+	if _, err := ca.client.CreateSubscription(ctx, ca.subscription, ca.namespace); err != nil {
 		logger.Debugf("Error creating subscriptions: %w", err)
 		return err
 	}
 
 	// Get a Succeeded or Failed CSV with one minute timeout
 	var err error
-	ca.csv, err = ca.client.GetCompletedCsvWithTimeout(ca.namespace, ca.csvWaitTime)
+	ca.csv, err = ca.client.GetCompletedCsvWithTimeout(ctx, ca.namespace, ca.csvWaitTime)
 
 	if err != nil {
 		// If error is timeout than don't log phase but timeout

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -32,10 +32,10 @@ type Client interface {
 	DeleteOperatorGroup(ctx context.Context, name string, namespace string) error
 	CreateSubscription(ctx context.Context, data SubscriptionData, namespace string) (*operatorv1alpha1.Subscription, error)
 	DeleteSubscription(ctx context.Context, name string, namespace string) error
-	GetCompletedCsvWithTimeout(namespace string, delay time.Duration) (operatorv1alpha1.ClusterServiceVersion, error)
-	GetOpenShiftVersion() (string, error)
+	GetCompletedCsvWithTimeout(ctx context.Context, namespace string, delay time.Duration) (operatorv1alpha1.ClusterServiceVersion, error)
+	GetOpenShiftVersion(ctx context.Context) (string, error)
 	ListPackageManifests(ctx context.Context, list *pkgserverv1.PackageManifestList, catalogSource string, filter []string) error
-	GetSubscriptionData(source string, namespace string, filter []string) ([]SubscriptionData, error)
+	GetSubscriptionData(ctx context.Context, source string, namespace string, filter []string) ([]SubscriptionData, error)
 	ListCRDs(ctx context.Context, list *apiextensionsv1.CustomResourceDefinitionList) error
 }
 

--- a/internal/operator/csv.go
+++ b/internal/operator/csv.go
@@ -12,13 +12,13 @@ import (
 )
 
 // Gets completed CSVs, Succeeded or Failed, with timeout on delay duration
-func (c operatorClient) GetCompletedCsvWithTimeout(namespace string, delay time.Duration) (operatorv1alpha1.ClusterServiceVersion, error) {
+func (c operatorClient) GetCompletedCsvWithTimeout(ctx context.Context, namespace string, delay time.Duration) (operatorv1alpha1.ClusterServiceVersion, error) {
 	// csv will catch CSVs from watch events
 	csv := &operatorv1alpha1.ClusterServiceVersion{}
 	var ok bool
 
 	// get watcher for csv
-	watcher, err := c.csvWatcher(namespace)
+	watcher, err := c.csvWatcher(ctx, namespace)
 	if err != nil {
 		return *csv, err
 	}
@@ -67,8 +67,7 @@ func (c operatorClient) GetCompletedCsvWithTimeout(namespace string, delay time.
 }
 
 // waits for CSV on namespace and gets a watcher for CSV events
-func (c operatorClient) csvWatcher(namespace string) (watch.Interface, error) {
-	ctx := context.Background()
+func (c operatorClient) csvWatcher(ctx context.Context, namespace string) (watch.Interface, error) {
 	var watcher watch.Interface
 
 	err := wait.ExponentialBackoff(wait.Backoff{Steps: 3, Duration: 2 * time.Second, Factor: 5, Cap: 90 * time.Second},

--- a/internal/operator/subscription.go
+++ b/internal/operator/subscription.go
@@ -25,9 +25,9 @@ type SubscriptionData struct {
 // SubscriptionList represent the set of operators
 // to be installed and tested
 // It's a unique list of package/channels for operator install
-func (c operatorClient) GetSubscriptionData(catalogSource string, catalogSourceNamespace string, filter []string) ([]SubscriptionData, error) {
+func (c operatorClient) GetSubscriptionData(ctx context.Context, catalogSource string, catalogSourceNamespace string, filter []string) ([]SubscriptionData, error) {
 	var packageManifests pkgserverv1.PackageManifestList
-	err := c.ListPackageManifests(context.Background(), &packageManifests, catalogSource, filter)
+	err := c.ListPackageManifests(ctx, &packageManifests, catalogSource, filter)
 	if err != nil {
 		logger.Errorf("Error while listing new PackageManifest Objects: %w", err)
 		return nil, err

--- a/internal/operator/version.go
+++ b/internal/operator/version.go
@@ -8,7 +8,7 @@ import (
 
 // GetOpenShiftVersion uses the OpenShift Config clientset to get a ClusterVersion resource which has the
 // version of an OpenShift cluster
-func (c operatorClient) GetOpenShiftVersion() (string, error) {
+func (c operatorClient) GetOpenShiftVersion(ctx context.Context) (string, error) {
 	// version is the OpenShift version of the cluster
 	var version string
 
@@ -18,7 +18,7 @@ func (c operatorClient) GetOpenShiftVersion() (string, error) {
 		return "", err
 	}
 
-	cversions, err := configClient.ClusterVersions().List(context.TODO(), metav1.ListOptions{})
+	cversions, err := configClient.ClusterVersions().List(ctx, metav1.ListOptions{})
 	if err != nil {
 		version = "0.0.0"
 		return version, err


### PR DESCRIPTION
The context should be created at the highest level, and the same context should be passed down through the code. Otherwise, it defeats the purpose of using the context in the first place.

Fixes #207

Signed-off-by: Brad P. Crochet <brad@redhat.com>
