### PR TITLE
Fix panic introduced by context param

### DIFF
--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -92,10 +92,12 @@ func (capAuditor *CapAuditor) RunAudits(ctx context.Context) error {
 		// read a particular audit's auditPlan for functions
 		// to be executed against operator
 		for _, function := range audit.auditPlan {
-
 			// run function/method by name
+			// NOTE: The signature for this method MUST be:
+			// func Fn(context.Context) error
 			m := reflect.ValueOf(&audit).MethodByName(function)
-			m.Call(nil)
+			in := []reflect.Value{reflect.ValueOf(ctx)}
+			m.Call(in)
 		}
 	}
 	return nil


### PR DESCRIPTION
## Description of PR
When the context parameter was added to the audit methods, it caused a panic. This was not caught because of the use of reflection. This will be a short-term fix for this panic. The long-term fix is to get rid of the reflection and instead opt for a standard interface that each audit can implement.

Fixes #220

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Added the context to the audit calls

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
