### PR TITLE
Refactor audits to remove reflection

### DIFF
--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -15,55 +15,68 @@ import (
 )
 
 // OperandCleanup removes the operand from the OCP cluster in the ca.namespace
-func (ca *capAudit) OperandCleanUp(ctx context.Context) error {
-	logger.Debugw("cleaningUp operand for operator", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode",
-		ca.subscription.InstallModeType)
-
-	if len(ca.customResources) > 0 {
-		for _, cr := range ca.customResources {
-			obj := &unstructured.Unstructured{Object: cr}
-
-			// using dynamic client to create Unstructured objests in k8s
-			client, err := operator.NewDynamicClient()
-			if err != nil {
-				return err
-			}
-
-			var crdList apiextensionsv1.CustomResourceDefinitionList
-			err = ca.client.ListCRDs(ctx, &crdList)
-			if err != nil {
-				return err
-			}
-
-			var Resource string
-
-			// iterate over the CRD list to find the CRD for the resource we are trying to delete
-			for _, crd := range crdList.Items {
-				if crd.Spec.Group == obj.GroupVersionKind().Group && crd.Spec.Names.Kind == obj.GroupVersionKind().Kind {
-					Resource = crd.Spec.Names.Plural
-				}
-			}
-
-			gvr := schema.GroupVersionResource{
-				Group:    obj.GroupVersionKind().Group,
-				Version:  obj.GroupVersionKind().Version,
-				Resource: Resource,
-			}
-
-			// extract name from CustomResource object and delete it
-			name := obj.Object["metadata"].(map[string]interface{})["name"].(string)
-
-			// check if CR exists, only then cleanup the operand
-			crInstance, _ := client.Resource(gvr).Namespace(ca.namespace).Get(ctx, name, v1.GetOptions{})
-			if crInstance != nil {
-				// delete the resource using the dynamic client
-				err = client.Resource(gvr).Namespace(ca.namespace).Delete(ctx, name, v1.DeleteOptions{})
-				if err != nil {
-					return fmt.Errorf("failed operatorCleanUp: %s: package: %s: %v", Resource, ca.subscription.Package, err)
-				}
+func operandCleanUp(ctx context.Context, opts ...auditOption) auditFn {
+	var options options
+	for _, opt := range opts {
+		err := opt(&options)
+		if err != nil {
+			return func(_ context.Context) error {
+				return fmt.Errorf("option failed: %v", err)
 			}
 		}
 	}
 
-	return nil
+	return func(ctx context.Context) error {
+		logger.Debugw("cleaningUp operand for operator", "package", options.Subscription.Package, "channel", options.Subscription.Channel, "installmode",
+			options.Subscription.InstallModeType)
+
+		if len(options.customResources) > 0 {
+			for _, cr := range options.customResources {
+				obj := &unstructured.Unstructured{Object: cr}
+
+				// using dynamic client to create Unstructured objests in k8s
+				client, err := operator.NewDynamicClient()
+				if err != nil {
+					return err
+				}
+
+				var crdList apiextensionsv1.CustomResourceDefinitionList
+				err = options.client.ListCRDs(ctx, &crdList)
+				if err != nil {
+					return err
+				}
+
+				var Resource string
+
+				// iterate over the CRD list to find the CRD for the resource we are trying to delete
+				for _, crd := range crdList.Items {
+					if crd.Spec.Group == obj.GroupVersionKind().Group && crd.Spec.Names.Kind == obj.GroupVersionKind().Kind {
+						Resource = crd.Spec.Names.Plural
+					}
+				}
+
+				gvr := schema.GroupVersionResource{
+					Group:    obj.GroupVersionKind().Group,
+					Version:  obj.GroupVersionKind().Version,
+					Resource: Resource,
+				}
+
+				// extract name from CustomResource object and delete it
+				name := obj.Object["metadata"].(map[string]interface{})["name"].(string)
+
+				// check if CR exists, only then cleanup the operand
+				crInstance, _ := client.Resource(gvr).Namespace(options.namespace).Get(ctx, name, v1.GetOptions{})
+				if crInstance != nil {
+					// delete the resource using the dynamic client
+					err = client.Resource(gvr).Namespace(options.namespace).Delete(ctx, name, v1.DeleteOptions{})
+					if err != nil {
+						logger.Debugf("failed operandCleanUp: %s package: %s error: %s\n", Resource, options.Subscription.Package, err.Error())
+						return err
+					}
+				}
+			}
+		}
+
+		return nil
+	}
 }

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -8,55 +8,65 @@ import (
 	"github.com/opdev/opcap/internal/logger"
 )
 
-func (ca *capAudit) OperatorInstall(ctx context.Context) error {
-	logger.Debugw("installing package", "package", ca.subscription.Package, "channel", ca.subscription.Channel, "installmode", ca.subscription.InstallModeType)
-	// create operator's own namespace
-	if _, err := ca.client.CreateNamespace(ctx, ca.namespace); err != nil {
-		return err
-	}
-
-	// create remaining target namespaces watched by the operator
-	for _, ns := range ca.operatorGroupData.TargetNamespaces {
-		if ns != ca.namespace {
-			ca.client.CreateNamespace(ctx, ns)
+func operatorInstall(ctx context.Context, opts ...auditOption) auditFn {
+	var options options
+	for _, opt := range opts {
+		err := opt(&options)
+		if err != nil {
+			return func(_ context.Context) error {
+				return fmt.Errorf("option failed: %v", err)
+			}
 		}
 	}
 
-	// create operator group for operator package/channel
-	ca.client.CreateOperatorGroup(ctx, ca.operatorGroupData, ca.namespace)
+	return func(ctx context.Context) error {
+		logger.Debugw("installing package", "package", options.Subscription.Package, "channel", options.Subscription.Channel, "installmode", options.Subscription.InstallModeType)
 
-	// create subscription for operator package/channel
-	if _, err := ca.client.CreateSubscription(ctx, ca.subscription, ca.namespace); err != nil {
-		return fmt.Errorf("could not create subscription: %v", err)
-	}
-
-	// Get a Succeeded or Failed CSV with one minute timeout
-	var err error
-	ca.csv, err = ca.client.GetCompletedCsvWithTimeout(ctx, ca.namespace, ca.csvWaitTime)
-
-	if err != nil {
-		// If error is timeout than don't log phase but timeout
-		if err.Error() == "operator install timeout" {
-			ca.csvTimeout = true
-		} else {
+		// create operator's own namespace
+		if _, err := options.client.CreateNamespace(ctx, options.namespace); err != nil {
 			return err
 		}
-	}
 
-	file, err := os.OpenFile("operator_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
-	if err != nil {
-		file.Close()
-		return err
-	}
-	defer file.Close()
+		// create remaining target namespaces watched by the operator
+		for _, ns := range options.operatorGroupData.TargetNamespaces {
+			if ns != options.namespace {
+				options.client.CreateNamespace(ctx, ns)
+			}
+		}
 
-	if err := ca.OperatorInstallJsonReport(file); err != nil {
-		return fmt.Errorf("could not generate OperatorInstall JSON report: %v", err)
-	}
+		// create operator group for operator package/channel
+		options.client.CreateOperatorGroup(ctx, *options.operatorGroupData, options.namespace)
 
-	if err := ca.OperatorInstallTextReport(os.Stdout); err != nil {
-		return fmt.Errorf("could not generate OperatorInstall Text report: %v", err)
-	}
+		// create subscription for operator package/channel
+		if _, err := options.client.CreateSubscription(ctx, *options.Subscription, options.namespace); err != nil {
+			logger.Debugf("Error creating subscriptions: %w", err)
+			return err
+		}
 
-	return nil
+		// Get a Succeeded or Failed CSV with one minute timeout
+		var err error
+		options.Csv, err = options.client.GetCompletedCsvWithTimeout(ctx, options.namespace, options.csvWaitTime)
+
+		if err != nil {
+			// If error is timeout than don't log phase but timeout
+			if err.Error() == "operator install timeout" {
+				options.CsvTimeout = true
+			} else {
+				return err
+			}
+		}
+
+		file, err := os.OpenFile("operator_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		if err != nil {
+			return err
+		}
+		defer file.Close()
+
+		// TODO: What to do with reports?
+		_ = operatorInstallJsonReport(file, options)
+
+		_ = operatorInstallTextReport(os.Stdout, options)
+
+		return nil
+	}
 }

--- a/internal/capability/report.go
+++ b/internal/capability/report.go
@@ -8,43 +8,43 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func (ca capAudit) OperatorInstallTextReport(w io.Writer) error {
+func operatorInstallTextReport(w io.Writer, ca options) error {
 	fmt.Fprint(w, "\n")
 	fmt.Fprint(w, "Operator Install Report:\n")
 	fmt.Fprint(w, "-----------------------------------------\n")
 	fmt.Fprintf(w, "Report Date: %s\n", time.Now())
-	fmt.Fprintf(w, "OpenShift Version: %s\n", ca.ocpVersion)
-	fmt.Fprintf(w, "Package Name: %s\n", ca.subscription.Package)
-	fmt.Fprintf(w, "Channel: %s\n", ca.subscription.Channel)
-	fmt.Fprintf(w, "Catalog Source: %s\n", ca.subscription.CatalogSource)
-	fmt.Fprintf(w, "Install Mode: %s\n", ca.subscription.InstallModeType)
+	fmt.Fprintf(w, "OpenShift Version: %s\n", ca.OcpVersion)
+	fmt.Fprintf(w, "Package Name: %s\n", ca.Subscription.Package)
+	fmt.Fprintf(w, "Channel: %s\n", ca.Subscription.Channel)
+	fmt.Fprintf(w, "Catalog Source: %s\n", ca.Subscription.CatalogSource)
+	fmt.Fprintf(w, "Install Mode: %s\n", ca.Subscription.InstallModeType)
 
-	if !ca.csvTimeout {
-		fmt.Fprintf(w, "Result: %s\n", ca.csv.Status.Phase)
+	if !ca.CsvTimeout {
+		fmt.Fprintf(w, "Result: %s\n", ca.Csv.Status.Phase)
 	} else {
 		fmt.Fprint(w, "Result: timeout\n")
 	}
 
-	fmt.Fprintf(w, "Message: %s\n", ca.csv.Status.Message)
-	fmt.Fprintf(w, "Reason: %s\n", ca.csv.Status.Reason)
+	fmt.Fprintf(w, "Message: %s\n", ca.Csv.Status.Message)
+	fmt.Fprintf(w, "Reason: %s\n", ca.Csv.Status.Reason)
 	fmt.Fprint(w, "-----------------------------------------\n")
 
 	return nil
 }
 
-func (ca capAudit) OperatorInstallJsonReport(w io.Writer) error {
-	if !ca.csvTimeout {
-		fmt.Fprintf(w, "{\"level\":\"info\",\"message\":\""+string(ca.csv.Status.Phase)+"\",\"package\":\""+ca.subscription.Package+
-			"\",\"channel\":\""+ca.subscription.Channel+"\",\"installmode\":\""+string(ca.subscription.InstallModeType)+"\"}\n")
+func operatorInstallJsonReport(w io.Writer, ca options) error {
+	if !ca.CsvTimeout {
+		fmt.Fprintf(w, "{\"level\":\"info\",\"message\":\""+string(ca.Csv.Status.Phase)+"\",\"package\":\""+ca.Subscription.Package+
+			"\",\"channel\":\""+ca.Subscription.Channel+"\",\"installmode\":\""+string(ca.Subscription.InstallModeType)+"\"}\n")
 	} else {
-		fmt.Fprintf(w, "{\"level\":\"info\",\"message\":\""+"timeout"+"\",\"package\":\""+ca.subscription.Package+"\",\"channel\":\""+
-			ca.subscription.Channel+"\",\"installmode\":\""+string(ca.subscription.InstallModeType)+"\"}\n")
+		fmt.Fprintf(w, "{\"level\":\"info\",\"message\":\""+"timeout"+"\",\"package\":\""+ca.Subscription.Package+"\",\"channel\":\""+
+			ca.Subscription.Channel+"\",\"installmode\":\""+string(ca.Subscription.InstallModeType)+"\"}\n")
 	}
 
 	return nil
 }
 
-func (ca capAudit) OperandTextReport(w io.Writer) error {
+func operandTextReport(w io.Writer, ca options) error {
 	for _, cr := range ca.customResources {
 		operand := &unstructured.Unstructured{Object: cr}
 
@@ -52,8 +52,8 @@ func (ca capAudit) OperandTextReport(w io.Writer) error {
 		fmt.Fprintf(w, "Operand Install Report:\n")
 		fmt.Fprintf(w, "-----------------------------------------\n")
 		fmt.Fprintf(w, "Report Date: %s\n", time.Now())
-		fmt.Fprintf(w, "OpenShift Version: %s\n", ca.ocpVersion)
-		fmt.Fprintf(w, "Package Name: %s\n", ca.subscription.Package)
+		fmt.Fprintf(w, "OpenShift Version: %s\n", ca.OcpVersion)
+		fmt.Fprintf(w, "Package Name: %s\n", ca.Subscription.Package)
 		fmt.Fprintf(w, "Operand Kind: %s\n", operand.GetKind())
 		fmt.Fprintf(w, "Operand Name: %s\n", operand.GetName())
 
@@ -67,15 +67,15 @@ func (ca capAudit) OperandTextReport(w io.Writer) error {
 	return nil
 }
 
-func (ca capAudit) OperandInstallJsonReport(w io.Writer) error {
+func operandInstallJsonReport(w io.Writer, ca options) error {
 	for _, cr := range ca.customResources {
 		operand := &unstructured.Unstructured{Object: cr}
 
 		if len(ca.operands) > 0 {
-			fmt.Fprintf(w, "{\"package\":\""+ca.subscription.Package+"\", \"Operand Kind\": \""+operand.GetKind()+"\", \"Operand Name\": \""+operand.GetName()+
+			fmt.Fprintf(w, "{\"package\":\""+ca.Subscription.Package+"\", \"Operand Kind\": \""+operand.GetKind()+"\", \"Operand Name\": \""+operand.GetName()+
 				"\",\"message\":\""+"created"+"\"}\n")
 		} else {
-			fmt.Fprintf(w, "{\"package\":\""+ca.subscription.Package+"\", \"Operand Kind\": \""+operand.GetKind()+"\", \"Operand Name\": \""+operand.GetName()+
+			fmt.Fprintf(w, "{\"package\":\""+ca.Subscription.Package+"\", \"Operand Kind\": \""+operand.GetKind()+"\", \"Operand Name\": \""+operand.GetName()+
 				"\",\"message\":\""+"failed"+"\"}\n")
 		}
 	}


### PR DESCRIPTION
## Description of PR

The reflection being used was error-prone, and changes to the audit signature resulted in a panic that should have been caught at compile time. But since reflection was being used, it did not allow for that type of error to be caught. This makes the audit calls more type-safe and changes can be caught before runtime.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #231 

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Refactor to remove reflection
- Use templates for reporting

## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
