### PR TITLE
Do not log errors except at the highest level

### DIFF
--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -2,10 +2,10 @@ package capability
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
-	"github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
@@ -51,17 +51,16 @@ type capAudit struct {
 	operands []unstructured.Unstructured
 }
 
-func newCapAudit(ctx context.Context, c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (capAudit, error) {
+func newCapAudit(ctx context.Context, c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (*capAudit, error) {
 	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-"), strings.ToLower(string(subscription.InstallModeType))}, "-")
 	operatorGroupName := strings.Join([]string{subscription.Name, subscription.Channel, "group"}, "-")
 
 	ocpVersion, err := c.GetOpenShiftVersion(ctx)
 	if err != nil {
-		logger.Debugw("Couldn't get OpenShift version for testing", "Err:", err)
-		return capAudit{}, err
+		return nil, fmt.Errorf("could not get OpenShift version for testing: %v", err)
 	}
 
-	return capAudit{
+	return &capAudit{
 		client:            c,
 		ocpVersion:        ocpVersion,
 		namespace:         ns,

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -2,6 +2,7 @@ package capability
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
@@ -58,8 +59,7 @@ func (ca *capAudit) OperandCleanUp(ctx context.Context) error {
 				// delete the resource using the dynamic client
 				err = client.Resource(gvr).Namespace(ca.namespace).Delete(ctx, name, v1.DeleteOptions{})
 				if err != nil {
-					logger.Debugf("failed operandCleanUp: %s package: %s error: %s\n", Resource, ca.subscription.Package, err.Error())
-					return err
+					return fmt.Errorf("failed operatorCleanUp: %s: package: %s: %v", Resource, ca.subscription.Package, err)
 				}
 			}
 		}

--- a/internal/capability/operator_cleanup.go
+++ b/internal/capability/operator_cleanup.go
@@ -2,35 +2,30 @@ package capability
 
 import (
 	"context"
-
-	"github.com/opdev/opcap/internal/logger"
+	"fmt"
 )
 
 func (ca *capAudit) OperatorCleanUp(ctx context.Context) error {
 	// delete subscription
 	if err := ca.client.DeleteSubscription(ctx, ca.subscription.Name, ca.namespace); err != nil {
-		logger.Debugf("Error while deleting Subscription: %w", err)
-		return err
+		return fmt.Errorf("could not delete subscription: %s: %v", ca.subscription.Name, err)
 	}
 
 	// delete operator group
 	if err := ca.client.DeleteOperatorGroup(ctx, ca.operatorGroupData.Name, ca.namespace); err != nil {
-		logger.Debugf("Error while deleting OperatorGroup: %w", err)
-		return err
+		return fmt.Errorf("could not delete OperatorGroup: %s: %v", ca.operatorGroupData.Name, err)
 	}
 
 	// delete target namespaces
 	for _, ns := range ca.operatorGroupData.TargetNamespaces {
 		if err := ca.client.DeleteNamespace(ctx, ns); err != nil {
-			logger.Debugf("Error deleting target namespace %s", ns)
-			return err
+			return fmt.Errorf("could not delete target namespace: %s: %v", ns, err)
 		}
 	}
 
 	// delete operator's own namespace
 	if err := ca.client.DeleteNamespace(ctx, ca.namespace); err != nil {
-		logger.Debugf("Error deleting operator's own namespace %s", ca.namespace)
-		return err
+		return fmt.Errorf("could not delete opeator's own namespace: %s: %v", ca.namespace, err)
 	}
 	return nil
 }

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -2,6 +2,7 @@ package capability
 
 import (
 	"context"
+	"fmt"
 	"os"
 
 	"github.com/opdev/opcap/internal/logger"
@@ -26,8 +27,7 @@ func (ca *capAudit) OperatorInstall(ctx context.Context) error {
 
 	// create subscription for operator package/channel
 	if _, err := ca.client.CreateSubscription(ctx, ca.subscription, ca.namespace); err != nil {
-		logger.Debugf("Error creating subscriptions: %w", err)
-		return err
+		return fmt.Errorf("could not create subscription: %v", err)
 	}
 
 	// Get a Succeeded or Failed CSV with one minute timeout
@@ -51,13 +51,11 @@ func (ca *capAudit) OperatorInstall(ctx context.Context) error {
 	defer file.Close()
 
 	if err := ca.OperatorInstallJsonReport(file); err != nil {
-		logger.Debugf("Error during the OperatorInstall Report: %w", err)
-		return err
+		return fmt.Errorf("could not generate OperatorInstall JSON report: %v", err)
 	}
 
 	if err := ca.OperatorInstallTextReport(os.Stdout); err != nil {
-		logger.Debugf("Error during the OperatorInstall Text Report: %w", err)
-		return err
+		return fmt.Errorf("could not generate OperatorInstall Text report: %v", err)
 	}
 
 	return nil

--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 
-	"github.com/opdev/opcap/internal/logger"
 	configv1 "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -72,8 +71,7 @@ func NewOpCapClient() (Client, error) {
 
 	client, err := runtimeClient.New(kubeconfig, runtimeClient.Options{Scheme: scheme})
 	if err != nil {
-		logger.Errorf("could not get subscription client")
-		return nil, err
+		return nil, fmt.Errorf("could not get subscription client: %v", err)
 	}
 
 	var operatorClient Client = &operatorClient{

--- a/internal/operator/csv.go
+++ b/internal/operator/csv.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/opdev/opcap/internal/logger"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -90,8 +89,7 @@ func (c operatorClient) csvWatcher(ctx context.Context, namespace string) (watch
 			return true, nil
 		})
 	if err != nil {
-		logger.Errorf("Failed to create csv.")
-		return nil, err
+		return nil, fmt.Errorf("could not create csv: %v", err)
 	}
 
 	return watcher, nil

--- a/internal/operator/namespace.go
+++ b/internal/operator/namespace.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/opdev/opcap/internal/logger"
 
@@ -19,8 +20,7 @@ func (o *operatorClient) CreateNamespace(ctx context.Context, name string) (*cor
 		},
 	}
 	if err := o.Client.Create(ctx, &nsSpec, &runtimeClient.CreateOptions{}); err != nil {
-		logger.Errorf("error while creating Namespace %s: %s", name, err.Error())
-		return nil, err
+		return nil, fmt.Errorf("could not create Namespace: %s: %v", name, err)
 	}
 	logger.Debugf("Namespace Created: %s", name)
 	return &nsSpec, nil
@@ -35,8 +35,7 @@ func (o *operatorClient) DeleteNamespace(ctx context.Context, name string) error
 		},
 	}
 	if err := o.Client.Delete(ctx, &nsSpec, &runtimeClient.DeleteOptions{}); err != nil {
-		logger.Errorf("error while deleting Namespace %s: %s", name, err.Error())
-		return err
+		return fmt.Errorf("could not delete namespace: %s: %v", name, err)
 	}
 	logger.Debugf("Namespace Deleted: %s", name)
 	return nil

--- a/internal/operator/namespace_test.go
+++ b/internal/operator/namespace_test.go
@@ -29,7 +29,7 @@ var _ = Describe("Namespace", func() {
 			By("creating it again should error", func() {
 				ns, err := operatorClient.CreateNamespace(context.TODO(), "testns")
 				Expect(err).To(HaveOccurred())
-				Expect(err).To(MatchError("namespaces \"testns\" already exists"))
+				Expect(err).To(MatchError("could not create Namespace: testns: namespaces \"testns\" already exists"))
 				Expect(ns).To(BeNil())
 			})
 			By("deleting that Namespace", func() {

--- a/internal/operator/operator_group.go
+++ b/internal/operator/operator_group.go
@@ -2,6 +2,7 @@ package operator
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/opdev/opcap/internal/logger"
 
@@ -27,8 +28,7 @@ func (o *operatorClient) CreateOperatorGroup(ctx context.Context, data OperatorG
 	}
 	err := o.Client.Create(ctx, operatorGroup)
 	if err != nil {
-		logger.Errorf("error while creating operatorgroup %s: %w", data.Name, err)
-		return nil, err
+		return nil, fmt.Errorf("could not create operatorgroup: %s: %v", data.Name, err)
 	}
 
 	logger.Debugw("operatorgroup created", "operatorgroup", data.Name, "namespace", namespace)
@@ -45,8 +45,7 @@ func (o *operatorClient) DeleteOperatorGroup(ctx context.Context, name string, n
 	}
 	err := o.Client.Delete(ctx, &operatorGroup)
 	if err != nil {
-		logger.Errorf("error while deleting OperatorGroup %s in namespace %s: %w", name, namespace, err)
-		return err
+		return fmt.Errorf("could not delete operatorgroup: %s: namespace: %s: %v", name, namespace, err)
 	}
 
 	logger.Debugw("operatorgroup deleted", "operatorgroup", name, "namespace", namespace)

--- a/internal/operator/subscription.go
+++ b/internal/operator/subscription.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/opdev/opcap/internal/logger"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -29,8 +28,7 @@ func (c operatorClient) GetSubscriptionData(ctx context.Context, catalogSource s
 	var packageManifests pkgserverv1.PackageManifestList
 	err := c.ListPackageManifests(ctx, &packageManifests, catalogSource, filter)
 	if err != nil {
-		logger.Errorf("Error while listing new PackageManifest Objects: %w", err)
-		return nil, err
+		return nil, fmt.Errorf("could not list PackageManifest objects: %v", err)
 	}
 
 	SubscriptionList := []SubscriptionData{}


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

Logging errors from internal can cause a lot of duplicate logs to
occur. Only allow Debug and Trace in the internal package. Everything
else should be passed up for logging later.
    
Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #234

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Only leave Trace and Debug logger calls in the internal package
- Pass errors back up the stack to be logged/printed at the root command.
- Do not use %w since we don't want the error passed back to be a part of the API.

## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
