### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -9,7 +9,6 @@ approvers:
 
 reviewers:
 - itroyano
-- makon57
-- rocrisp
 - skattoju
-- spabba17
+- OchiengEd
+- bcrochet


### PR DESCRIPTION
Add/remove some reviewers. Our automation picks reviewers from here and makes sense to have folks actively performing reviews listed at this time.

Resolves #237

- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have checked that my changes pass all tests