### PR TITLE
Allow users to provide additional Custom Resources

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -64,7 +64,7 @@ and/or users.`,
 
 			return nil
 		},
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			capAuditor := &capability.CapAuditor{
 				AuditPlan:              checkflags.AuditPlan,
 				CatalogSource:          checkflags.CatalogSource,
@@ -74,7 +74,11 @@ and/or users.`,
 			}
 
 			// run all dynamically built audits in the auditor workqueue
-			capAuditor.RunAudits(cmd.Context())
+			if err := capAuditor.RunAudits(cmd.Context()); err != nil {
+				return err
+			}
+
+			return nil
 		},
 	}
 

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -21,6 +21,7 @@ type CheckCommandFlags struct {
 	ListPackages           bool     `json:"listPackages"`
 	Packages               []string `json:"packages"`
 	AllInstallModes        bool     `json:"allInstallModes"`
+	ExtraCRDirectory       string   `json:"extraCRDirectory"`
 }
 
 var checkflags CheckCommandFlags
@@ -73,6 +74,12 @@ and/or users.`,
 				AllInstallModes:        checkflags.AllInstallModes,
 			}
 
+			if checkflags.ExtraCRDirectory != "" {
+				if err := capAuditor.ExtraCRDirectory(checkflags.ExtraCRDirectory); err != nil {
+					return err
+				}
+			}
+
 			// run all dynamically built audits in the auditor workqueue
 			if err := capAuditor.RunAudits(cmd.Context()); err != nil {
 				return err
@@ -93,6 +100,8 @@ and/or users.`,
 	flags.StringSliceVar(&checkflags.AuditPlan, "audit-plan", defaultAuditPlan, "audit plan is the ordered list of operator test functions to be called during a capability audit.")
 	flags.StringSliceVar(&checkflags.Packages, "packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
 	flags.BoolVar(&checkflags.AllInstallModes, "all-installmodes", false, "when set, all install modes supported by an operator will be tested")
+	flags.StringVar(&checkflags.ExtraCRDirectory, "extra-cr-directory", "",
+		"directory containing the additional Custom Resources to be deployed by the OperandInstall audit. The manifest files should be located in subdirectories named after the packages they are corresponding to.")
 
 	return cmd
 }

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -52,7 +52,7 @@ type capAudit struct {
 	operands []unstructured.Unstructured
 }
 
-func newCapAudit(ctx context.Context, c operator.Client, subscription operator.SubscriptionData, auditPlan []string) (*capAudit, error) {
+func newCapAudit(ctx context.Context, c operator.Client, subscription operator.SubscriptionData, auditPlan []string, extraCustomResources []map[string]interface{}) (*capAudit, error) {
 	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-"), strings.ToLower(string(subscription.InstallModeType))}, "-")
 	operatorGroupName := strings.Join([]string{subscription.Name, subscription.Channel, "group"}, "-")
 
@@ -70,6 +70,7 @@ func newCapAudit(ctx context.Context, c operator.Client, subscription operator.S
 		csvWaitTime:       time.Minute,
 		csvTimeout:        false,
 		auditPlan:         auditPlan,
+		customResources:   extraCustomResources,
 	}, nil
 }
 
@@ -159,6 +160,14 @@ func withTimeout(csvWaitTime int) auditOption {
 func withOcpVersion(ocpVersion string) auditOption {
 	return func(options *options) error {
 		options.OcpVersion = ocpVersion
+		return nil
+	}
+}
+
+// withCustomResources adds existing Custom Resources to the audit
+func withCustomResources(customResources []map[string]interface{}) auditOption {
+	return func(options *options) error {
+		options.customResources = customResources
 		return nil
 	}
 }

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -3,9 +3,14 @@ package capability
 import (
 	"context"
 	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
+	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
 // capAuditor implements Auditor
@@ -26,6 +31,90 @@ type CapAuditor struct {
 
 	// AllInstallModes will test all install modes supported by an operator
 	AllInstallModes bool
+
+	// extraCustomResources associates packages to a list of Custom Resources (in addition to ALMExamples)
+	// to be audited by the OperandInstall AuditPlan.
+	extraCustomResources map[string]interface{}
+}
+
+// ExtraCRDirectory scans the provided directory and populates the extraCustomResources field.
+// Is is expected that the extraCRDirectory posesses subdirectories. Manifest files are present in each subdirectory.
+// The name of the subdirectory is used to determine which package the manifest files are corresponding to.
+// The resulting structure would be:
+// custom_resources_directory/
+// ├── package_name1
+// │   ├── manifest_file1.json
+// │   └── manifest_file2.yaml
+// └── package_name2
+//     ├── manifest_file1.json
+//     └── manifest_file2.yaml
+func (capAuditor *CapAuditor) ExtraCRDirectory(extraCRDirectory string) error {
+	logger.Debugw("scaning for extra Custom Resources", "extra CR directory", extraCRDirectory)
+	extraCustomResources := map[string]interface{}{} // maps packages to a list of CR
+
+	extraCRDirectoryAbsolutePath, err := filepath.Abs(extraCRDirectory)
+	if err != nil {
+		return fmt.Errorf("could not get absolute path from %s: %v", extraCRDirectory, err)
+	}
+
+	err = filepath.WalkDir(extraCRDirectoryAbsolutePath, func(path string, d fs.DirEntry, err error) error {
+		if err != nil && path == extraCRDirectoryAbsolutePath {
+			// Error reading the root directory, exit and return the error
+			return err
+		}
+
+		if !d.IsDir() { // Act on files only
+			manifestFilePath := path
+			// Checking that the manifest file is placed in a subdirectory
+			if len(strings.Split(manifestFilePath, "/")) != len(strings.Split(extraCRDirectoryAbsolutePath, "/"))+2 {
+				logger.Errorf("Error handling manifest file %s. File should be placed in a subdirectory of %s", manifestFilePath, extraCRDirectory)
+				return nil // continue
+			}
+
+			// Get the name of the subdirectory containing the manifest file. This corresponds to the package name.
+			packageName := filepath.Base(filepath.Dir(manifestFilePath))
+
+			logger.Debugw("adding Custom Resource", "source manifest file", manifestFilePath, "package", packageName)
+
+			// Get manifest file content
+			manifestBytes, err := os.ReadFile(manifestFilePath)
+			if err != nil {
+				logger.Errorf("Error reading file %s: %v", manifestFilePath, err)
+				return nil // continue
+			}
+
+			var manifest map[string]interface{}
+			err = yaml.Unmarshal(manifestBytes, &manifest)
+			if err != nil {
+				logger.Errorf("Error unmarshalling file %s: %v", manifestFilePath, err)
+				return nil // continue
+			}
+
+			if manifest == nil {
+				logger.Errorf("Empty manifest file %s", manifestFilePath)
+				return nil // continue
+			}
+
+			// Add the Custom Resource to the list of extra Custom Resource for this package
+			var customResourceManifests []map[string]interface{}
+			if _, packageKeyPresent := extraCustomResources[packageName]; packageKeyPresent {
+				customResourceManifests = extraCustomResources[packageName].([]map[string]interface{})
+			}
+			customResourceManifests = append(customResourceManifests, manifest)
+
+			extraCustomResources[packageName] = customResourceManifests
+		}
+
+		return nil
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not read directory %s: %v", extraCRDirectory, err)
+	}
+
+	capAuditor.extraCustomResources = extraCustomResources
+
+	return nil
 }
 
 // BuildWorkQueueByCatalog fills in the auditor workqueue with all package information found in a specific catalog
@@ -66,7 +155,14 @@ func (capAuditor *CapAuditor) buildWorkQueueByCatalog(ctx context.Context) error
 
 	// add capAudits to the workqueue
 	for _, subscription := range packagesToBeAudited {
-		capAudit, err := newCapAudit(ctx, c, subscription, capAuditor.AuditPlan)
+		// Get extra Custom Resources for this subscription, if any
+		mapExtraCustomResources := []map[string]interface{}{}
+		extraCustomResources, ok := capAuditor.extraCustomResources[subscription.Package]
+		if ok {
+			mapExtraCustomResources = extraCustomResources.([]map[string]interface{})
+		}
+
+		capAudit, err := newCapAudit(ctx, c, subscription, capAuditor.AuditPlan, mapExtraCustomResources)
 		if err != nil {
 			return fmt.Errorf("could not build configuration for subscription: %s: %v", subscription.Name, err)
 		}
@@ -99,6 +195,7 @@ func (capAuditor *CapAuditor) RunAudits(ctx context.Context) error {
 				withOperatorGroupData(&audit.operatorGroupData),
 				withSubscription(&audit.subscription),
 				withTimeout(int(audit.csvWaitTime)),
+				withCustomResources(audit.customResources),
 			)
 			if auditFn == nil {
 				logger.Errorf("invalid audit plan specified: %s", function)

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -43,7 +43,7 @@ func extractAlmExamples(ctx context.Context, options *options) error {
 		return err
 	}
 
-	options.customResources = almList
+	options.customResources = append(options.customResources, almList...)
 
 	return nil
 }


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

Adds the '--extra-cr-directory' flag to the check command. The expected directory structures is:
```
custom_resources_directory/
├── package_name1
│   ├── manifest_file1.json
│   └── manifest_file2.yaml
└── package_name2
    ├── manifest_file1.json
    └── manifest_file2.yaml
```
Additional CRs can be specified for multiple packages by creating multiple subdirectories. The name of the subdirectory should correspond to the name of the package the manifest files are to be be deployed with.

Multiple manifest files can be specified for each package. Both JSON and YAML formats are accepted.

The additional CRs are merged with the ALMExamples, if any.



<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #130

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Add the `--extra-cr-directory` flag to the check command
- Load extra CRs from this directory.
- Add a `ExtraCustomResources` field to the `capAuditor` struct, associating packages to a list of extra CRs.
- Add the extra CR to corresponding Audits.
- Edit the `extractAlmExamples` function, so that both ALMExamples and extra CRs are installed.

<!--Please list any items deprecated by your PR. Feel free to remove this section if unused.-->
## Deprecations (optional)

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests

<!--Please list any external references that might be helpful in understanding your changes.
Feel free to remove this section if unused.-->
## References (optional)