### PR TITLE
Move reports to use templates

### DIFF
--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -131,13 +131,11 @@ func operandInstall(ctx context.Context, opts ...auditOption) auditFn {
 		defer file.Close()
 
 		if err := operandInstallJsonReport(file, options); err != nil {
-			logger.Debugf("Error during the OperandInstall Report: %w", err)
-			return err
+			return fmt.Errorf("could not generate operand install JSON report: %v", err)
 		}
 
-		if err := operandTextReport(os.Stdout, options); err != nil {
-			logger.Debugf("Error during the OperandInstall Text Report: %w", err)
-			return err
+		if err := operandInstallTextReport(os.Stdout, options); err != nil {
+			return fmt.Errorf("could not generate operand install text report: %v", err)
 		}
 
 		return nil

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -62,10 +62,13 @@ func operatorInstall(ctx context.Context, opts ...auditOption) auditFn {
 		}
 		defer file.Close()
 
-		// TODO: What to do with reports?
-		_ = operatorInstallJsonReport(file, options)
+		if err := operatorInstallJsonReport(file, options); err != nil {
+			return fmt.Errorf("could not generate operator install JSON report: %v", err)
+		}
 
-		_ = operatorInstallTextReport(os.Stdout, options)
+		if err := operatorInstallTextReport(os.Stdout, options); err != nil {
+			return fmt.Errorf("could not generate operator install text report: %v", err)
+		}
 
 		return nil
 	}

--- a/internal/capability/report_test.go
+++ b/internal/capability/report_test.go
@@ -1,0 +1,162 @@
+package capability
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opdev/opcap/internal/operator"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Report", func() {
+	Describe("Template process test", func() {
+		When("an invaild template is passed", func() {
+			It("should return an error", func() {
+				Expect(processTemplate(&strings.Builder{}, "{{ .Invalid }", &struct{}{})).ToNot(Succeed())
+			})
+		})
+		When("an the writer errors", func() {
+			It("should return an error", func() {
+				Expect(processTemplate(errWriter(0), "this is the template", &struct{}{})).ToNot(Succeed())
+			})
+		})
+	})
+	Describe("Report template tests", func() {
+		var w strings.Builder
+		var opts options
+
+		BeforeEach(func() {
+			DeferCleanup(w.Reset)
+			opts = options{
+				Subscription: &operator.SubscriptionData{
+					Name:            "testsub",
+					Channel:         "test",
+					InstallModeType: v1alpha1.InstallModeTypeAllNamespaces,
+					Package:         "testpackage",
+					CatalogSource:   "testcatalog",
+				},
+				operatorGroupData: &operator.OperatorGroupData{},
+				namespace:         "testns",
+				CsvTimeout:        false,
+				Csv: v1alpha1.ClusterServiceVersion{
+					Status: v1alpha1.ClusterServiceVersionStatus{
+						Phase:   v1alpha1.CSVPhaseSucceeded,
+						Message: "message",
+						Reason:  v1alpha1.CSVReasonInstallSuccessful,
+					},
+				},
+				OcpVersion: "4.11",
+				customResources: []map[string]interface{}{
+					{
+						"kind": "testkind",
+						"metadata": map[string]interface{}{
+							"name": "testname",
+						},
+					},
+				},
+				operands: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"metadata": map[string]interface{}{
+								"kind": "testkind",
+								"name": "testname",
+							},
+						},
+					},
+				},
+			}
+		})
+		Context("Operator reports", func() {
+			When("generating a JSON report", func() {
+				When("given successful data", func() {
+					It("should create a valid JSON report", func() {
+						Expect(operatorInstallJsonReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(MatchJSON(`{"level":"info","message":"Succeeded","package":"testpackage","channel":"test","installmode":"AllNamespaces"}`))
+					})
+				})
+				When("given a timeout", func() {
+					BeforeEach(func() {
+						opts.CsvTimeout = true
+					})
+					It("should report a timeout", func() {
+						Expect(operatorInstallJsonReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(MatchJSON(`{"level":"info","message":"timeout","package":"testpackage","channel":"test","installmode":"AllNamespaces"}`))
+					})
+				})
+			})
+			When("generating a text report", func() {
+				When("given successful data", func() {
+					It("should print a report", func() {
+						Expect(operatorInstallTextReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(ContainSubstring("OpenShift Version: %s", "4.11"))
+						Expect(w.String()).To(ContainSubstring("Package Name: %s", "testpackage"))
+						Expect(w.String()).To(ContainSubstring("Channel: %s", "test"))
+						Expect(w.String()).To(ContainSubstring("Catalog Source: %s", "testcatalog"))
+						Expect(w.String()).To(ContainSubstring("Install Mode: %s", "AllNamespaces"))
+						Expect(w.String()).To(ContainSubstring("Result: %s", "Succeeded"))
+						Expect(w.String()).To(ContainSubstring("Message: %s", "message"))
+						Expect(w.String()).To(ContainSubstring("Reason: %s", "InstallSucceeded"))
+					})
+				})
+				When("given a timeout", func() {
+					BeforeEach(func() {
+						opts.CsvTimeout = true
+					})
+					It("should report a timeout", func() {
+						Expect(operatorInstallTextReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(ContainSubstring("Result: %s", "timeout"))
+					})
+				})
+			})
+		})
+		Context("Operand reports", func() {
+			When("generating a JSON report", func() {
+				When("given successful data", func() {
+					It("should create a valid JSON report", func() {
+						Expect(operandInstallJsonReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(MatchJSON(`{"package":"testpackage","Operand Kind":"testkind","Operand Name":"testname","message":"created"}`))
+					})
+				})
+				When("given no operands", func() {
+					BeforeEach(func() {
+						opts.operands = []unstructured.Unstructured{}
+					})
+					It("should report failed", func() {
+						Expect(operandInstallJsonReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(MatchJSON(`{"package":"testpackage","Operand Kind":"testkind","Operand Name":"testname","message":"failed"}`))
+					})
+				})
+			})
+			When("generating a text report", func() {
+				When("given successful data", func() {
+					It("should print a report", func() {
+						Expect(operandInstallTextReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(ContainSubstring("OpenShift Version: %s", "4.11"))
+						Expect(w.String()).To(ContainSubstring("Package Name: %s", "testpackage"))
+						Expect(w.String()).To(ContainSubstring("Operand Kind: %s", "testkind"))
+						Expect(w.String()).To(ContainSubstring("Operand Name: %s", "testname"))
+						Expect(w.String()).To(ContainSubstring("Operand Creation: %s", "Succeeded"))
+					})
+				})
+				When("given no operands", func() {
+					BeforeEach(func() {
+						opts.operands = []unstructured.Unstructured{}
+					})
+					It("should report failed", func() {
+						Expect(operandInstallTextReport(&w, opts)).To(Succeed())
+						Expect(w.String()).To(ContainSubstring("Operand Creation: %s", "Failed"))
+					})
+				})
+			})
+		})
+	})
+})
+
+type errWriter int
+
+func (errWriter) Write(p []byte) (int, error) {
+	return 0, fmt.Errorf("write error")
+}

--- a/internal/capability/suite_test.go
+++ b/internal/capability/suite_test.go
@@ -1,0 +1,13 @@
+package capability
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestCapability(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Operator Suite")
+}


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
This patch cuts down on quite a bit of shared code, and extracts the differences between the reports out into template strings, instead of the differences being in Fprintf statements in multiple funcs.

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #239

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Use text templates for reports
- Add tests

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests

Signed-off-by: Brad P. Crochet <brad@redhat.com>

