### PR TITLE
Fix the log message that were saying "Ignored key"

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -4,7 +4,6 @@ import (
 	"os"
 
 	"go.uber.org/zap"
-	"go.uber.org/zap/zapcore"
 )
 
 var (
@@ -13,10 +12,7 @@ var (
 	cfg    zap.Config
 )
 
-var (
-	logger      *zap.Logger
-	sugarLogger *zap.SugaredLogger
-)
+var sugarLogger *zap.SugaredLogger
 
 // InitLogger creates the Sugared Zap Logger
 // logLevel could be set either through the flag "--log-level" or environment variable OPCAP_LOG_LEVEL
@@ -32,41 +28,36 @@ func InitLogger(logLevel string) error {
 		return err
 	}
 
-	cfg = zap.Config{
-		Level:       atomicLevel,
-		Encoding:    "json",
-		OutputPaths: []string{"stdout"},
-		EncoderConfig: zapcore.EncoderConfig{
-			MessageKey: "message",
-			LevelKey:   "level",
-		},
-	}
+	cfg = zap.NewProductionConfig()
+	cfg.Level = atomicLevel
+	cfg.EncoderConfig.MessageKey = "message"
 
 	logger, err := cfg.Build()
 	if err != nil {
 		return err
 	}
+
 	sugarLogger = logger.Sugar()
 
 	return nil
 }
 
 // info exports Info Suggared Loglevel
-func Info(message string, fields ...interface{}) {
-	sugarLogger.Info(message, fields)
+func Infow(message string, fields ...interface{}) {
+	sugarLogger.Infow(message, fields...)
 }
 
 // debugw exports Suggared Loglevel
 func Debugw(message string, fields ...interface{}) {
-	sugarLogger.Debugw(message, fields)
+	sugarLogger.Debugw(message, fields...)
 }
 
 // debugf exports Suggared Loglevel
 func Debugf(message string, fields ...interface{}) {
-	sugarLogger.Debugf(message, fields)
+	sugarLogger.Debugf(message, fields...)
 }
 
 // errorf exports Suggared Loglevel
 func Errorf(message string, fields ...interface{}) {
-	sugarLogger.Errorf(message, fields)
+	sugarLogger.Errorf(message, fields...)
 }

--- a/internal/logger/logger_test.go
+++ b/internal/logger/logger_test.go
@@ -1,0 +1,75 @@
+package logger
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func setupLogCapture() (*zap.Logger, *observer.ObservedLogs) {
+	core, logs := observer.New(zap.DebugLevel)
+	return zap.New(core), logs
+}
+
+var _ = Describe("Logger", func() {
+	Context("Init Logger", func() {
+		When("passed an incorrect level", func() {
+			It("should return an error", func() {
+				Expect(InitLogger("badlevel")).ToNot(Succeed())
+			})
+		})
+	})
+	Context("Log statements", func() {
+		var logs *observer.ObservedLogs
+		BeforeEach(func() {
+			// Just use the lowest level
+			Expect(InitLogger("debug")).To(Succeed())
+			var logger *zap.Logger
+			logger, logs = setupLogCapture()
+			sugarLogger = logger.Sugar()
+		})
+		When("logging with Debugw", func() {
+			It("should log the right thing", func() {
+				Debugw("debugw", "key", "value")
+				Expect(logs.Len()).To(Equal(1))
+				entry := logs.All()[0]
+				Expect(entry.Level).To(Equal(zap.DebugLevel))
+				Expect(entry.Message).To(Equal("debugw"))
+				Expect(entry.ContextMap()).To(ContainElement("value"))
+				// TODO: uncomment when this matcher lands in a Gomega release
+				// Expect("key").Should(BeKeyOf(entry.ContextMap()))
+			})
+		})
+		When("Logging with Debugf", func() {
+			It("should log the right thing", func() {
+				Debugf("debugf %s", "value")
+				Expect(logs.Len()).To(Equal(1))
+				entry := logs.All()[0]
+				Expect(entry.Level).To(Equal(zap.DebugLevel))
+				Expect(entry.Message).To(Equal("debugf value"))
+			})
+		})
+		When("Logging with Errorf", func() {
+			It("should log the right thing", func() {
+				Errorf("errorf %s", "value")
+				Expect(logs.Len()).To(Equal(1))
+				entry := logs.All()[0]
+				Expect(entry.Level).To(Equal(zap.ErrorLevel))
+				Expect(entry.Message).To(Equal("errorf value"))
+			})
+		})
+		When("Logging with Info", func() {
+			It("should log the right thing", func() {
+				Infow("infow", "key", "value")
+				Expect(logs.Len()).To(Equal(1))
+				entry := logs.All()[0]
+				Expect(entry.Level).To(Equal(zap.InfoLevel))
+				Expect(entry.Message).To(Equal("infow"))
+				Expect(entry.ContextMap()).To(ContainElement("value"))
+				// TODO: uncomment when this matcher lands in a Gomega release
+				// Expect("key").Should(BeKeyOf(entry.ContextMap()))
+			})
+		})
+	})
+})

--- a/internal/logger/suite_test.go
+++ b/internal/logger/suite_test.go
@@ -1,0 +1,13 @@
+package logger
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLoggerSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Logger suite")
+}

--- a/internal/operator/namespace_test.go
+++ b/internal/operator/namespace_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/opdev/opcap/internal/logger"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -15,7 +14,6 @@ var _ = Describe("Namespace", func() {
 	var operatorClient operatorClient
 
 	BeforeEach(func() {
-		logger.InitLogger("debug")
 		scheme := runtime.NewScheme()
 		corev1.AddToScheme(scheme)
 		client := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/internal/operator/operator_group_test.go
+++ b/internal/operator/operator_group_test.go
@@ -5,7 +5,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/opdev/opcap/internal/logger"
 	operatorv1 "github.com/operator-framework/api/pkg/operators/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -16,7 +15,6 @@ var _ = Describe("OperatorGroup", func() {
 	var operatorGroupData OperatorGroupData
 
 	BeforeEach(func() {
-		logger.InitLogger("debug")
 		scheme := runtime.NewScheme()
 		operatorv1.AddToScheme(scheme)
 		client := fake.NewClientBuilder().WithScheme(scheme).Build()

--- a/internal/operator/operator_suite_test.go
+++ b/internal/operator/operator_suite_test.go
@@ -5,9 +5,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/opdev/opcap/internal/logger"
 )
 
 func TestOperator(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operator Suite")
 }
+
+var _ = BeforeSuite(func() {
+	logger.InitLogger("error")
+})


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

The variadic args to the wrapped logger needed to be expanded when being sent to the sugared logger. Instead, what was happening is that the arg was being passed as a single arg. Thus, zap thought that it was just a key being passed, with no matching value.

* Add unit tests for the logger
* Simplify the config of the logger
* Switch to using stderr instead of stdout
* Fix the variadic args


Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #247

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

* Add unit tests for the logger
* Simplify the config of the logger
* Switch to using stderr instead of stdout
* Fix the variadic args

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests

