### PR TITLE
Allow all operands to be tried on error

### DIFF
--- a/internal/logger/logger.go
+++ b/internal/logger/logger.go
@@ -61,3 +61,8 @@ func Debugf(message string, fields ...interface{}) {
 func Errorf(message string, fields ...interface{}) {
 	sugarLogger.Errorf(message, fields...)
 }
+
+// Errorw exports sugared LogLevel Error
+func Errorw(message string, fields ...interface{}) {
+	sugarLogger.Errorw(message, fields...)
+}


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

Instead of exiting on an operand failure, allow the audit to continue and report on all operands.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #248

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

* Do not return an error on a per-operand basis
* Pull setup code out of the main operand loop

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
