### PR TITLE
Refactor client creation to test CSV operations

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/opdev/opcap/internal/capability"
+	"github.com/opdev/opcap/internal/operator"
 
 	"github.com/spf13/cobra"
 )
@@ -28,12 +31,23 @@ advanced features by running custom resources provided by CSVs
 and/or users.`,
 		Example: "opcap check --catalogsource=certified-operators --catalogsourcenamespace=openshift-marketplace",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			kubeconfig, err := kubeConfig()
+			if err != nil {
+				return fmt.Errorf("could not get kubeconfig: %v", err)
+			}
+
+			client, err := operator.NewOpCapClient(kubeconfig)
+			if err != nil {
+				return fmt.Errorf("could not create client: %v", err)
+			}
+
 			capAuditor := &capability.CapAuditor{
 				AuditPlan:              checkflags.AuditPlan,
 				CatalogSource:          checkflags.CatalogSource,
 				CatalogSourceNamespace: checkflags.CatalogSourceNamespace,
 				Packages:               checkflags.Packages,
 				AllInstallModes:        checkflags.AllInstallModes,
+				OpCapClient:            client,
 			}
 
 			if checkflags.ExtraCRDirectory != "" {

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -86,7 +86,11 @@ func uploadCmd() *cobra.Command {
 
 func uploadPreRunE(cmd *cobra.Command, args []string) error {
 	cmd.SilenceUsage = true
-	opClient, err := operator.NewOpCapClient()
+	kubeconfig, err := kubeConfig()
+	if err != nil {
+		return fmt.Errorf("could not get kubeconfig: %v", err)
+	}
+	opClient, err := operator.NewOpCapClient(kubeconfig)
 	if err != nil {
 		return fmt.Errorf("failed to initialize OpenShift client: %v", err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/gobuffalo/envy v1.10.1
 	github.com/minio/minio-go/v7 v7.0.27
 	github.com/onsi/ginkgo/v2 v2.1.6
-	github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0
 	github.com/operator-framework/api v0.17.0
 	github.com/operator-framework/operator-lifecycle-manager v0.19.1
 	k8s.io/api v0.24.0
@@ -30,7 +29,7 @@ require (
 	github.com/minio/md5-simd v1.1.0 // indirect
 	github.com/minio/sha256-simd v0.1.1 // indirect
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
-	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd // indirect
+	github.com/openshift/api v0.0.0-20200331152225-585af27e34fd
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/rs/xid v1.2.1 // indirect
 	go.uber.org/atomic v1.7.0 // indirect
@@ -94,6 +93,7 @@ require (
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
+	k8s.io/apiserver v0.24.0 // indirect
 	k8s.io/component-base v0.24.0 // indirect
 	k8s.io/klog/v2 v2.60.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20220328201542-3ee0da9b0b42 // indirect

--- a/go.sum
+++ b/go.sum
@@ -867,7 +867,6 @@ github.com/openshift/api v0.0.0-20200326152221-912866ddb162/go.mod h1:RKMJ5CBnlj
 github.com/openshift/api v0.0.0-20200331152225-585af27e34fd h1:f4iPC9iCf1an7qEWpEFvp/swsM79vvBRsJ2twU4D30s=
 github.com/openshift/api v0.0.0-20200331152225-585af27e34fd/go.mod h1:RKMJ5CBnljLfnej+BJ/xnOWc3kZDvJUaIAEq2oKSPtE=
 github.com/openshift/build-machinery-go v0.0.0-20200211121458-5e3d6e570160/go.mod h1:1CkcsT3aVebzRBzVTSbiKSkJMsC/CASqxesfqEMfJEc=
-github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0 h1:kMiuiZXH1GdfbiMwsuAQOqGaMxlo9NCUk0wT4XAdfNM=
 github.com/openshift/client-go v0.0.0-20200326155132-2a6cd50aedd0/go.mod h1:uUQ4LClRO+fg5MF/P6QxjMCb1C9f7Oh4RKepftDnEJE=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=

--- a/internal/operator/csv_test.go
+++ b/internal/operator/csv_test.go
@@ -1,0 +1,87 @@
+package operator
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	olmfake "github.com/operator-framework/operator-lifecycle-manager/pkg/api/client/clientset/versioned/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("CSV", func() {
+	var client operatorClient
+	var csv operatorv1alpha1.ClusterServiceVersion
+
+	BeforeEach(func() {
+		csv = operatorv1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testcsv",
+				Namespace: "testns",
+			},
+			Status: operatorv1alpha1.ClusterServiceVersionStatus{
+				Phase: operatorv1alpha1.CSVPhaseInstalling,
+			},
+		}
+
+		scheme := runtime.NewScheme()
+		Expect(addSchemes(scheme)).To(Succeed())
+
+		fakeClient := fake.NewClientBuilder().
+			WithObjects(&csv).
+			WithScheme(scheme).
+			Build()
+
+		objs := []runtime.Object{
+			&csv,
+		}
+
+		fakeOlmClient := olmfake.NewSimpleClientset(objs...)
+
+		client = operatorClient{
+			Client:    fakeClient,
+			OlmClient: fakeOlmClient,
+		}
+	})
+	When("testing for a CSV", func() {
+		When("the CSV is updated", func() {
+			It("should get a completed CSV", func() {
+				var resultCsv *operatorv1alpha1.ClusterServiceVersion
+				var err error
+				done := make(chan interface{})
+				go func() {
+					resultCsv, err = client.GetCompletedCsvWithTimeout(context.Background(), "testns", time.Second*30)
+					close(done)
+				}()
+
+				// Allow some time for the CSV method to get going
+				time.Sleep(time.Millisecond)
+				updatedCsv := csv.DeepCopy()
+				updatedCsv.Status.Phase = operatorv1alpha1.CSVPhaseSucceeded
+				Expect(client.OlmClient.OperatorsV1alpha1().ClusterServiceVersions("testns").UpdateStatus(
+					context.Background(),
+					updatedCsv,
+					metav1.UpdateOptions{},
+				)).ToNot(BeNil())
+
+				Eventually(done, time.Second*60).Should(BeClosed())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(resultCsv).ToNot(BeNil())
+				Expect(resultCsv).To(Equal(updatedCsv))
+			})
+		})
+		When("no CSV is updated", func() {
+			It("should timeout", func() {
+				resultCsv, err := client.GetCompletedCsvWithTimeout(context.Background(), "testns", time.Second*2)
+				Expect(err).To(HaveOccurred())
+				Expect(err).To(Equal(TimeoutError))
+				Expect(resultCsv).To(BeNil())
+			})
+		})
+	})
+})

--- a/internal/operator/olm.go
+++ b/internal/operator/olm.go
@@ -1,0 +1,12 @@
+package operator
+
+import (
+	"context"
+
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func (c operatorClient) ListClusterServiceVersions(ctx context.Context, namespace string) (*operatorv1alpha1.ClusterServiceVersionList, error) {
+	return c.OlmClient.OperatorsV1alpha1().ClusterServiceVersions(namespace).List(ctx, v1.ListOptions{})
+}

--- a/internal/operator/unstructured.go
+++ b/internal/operator/unstructured.go
@@ -1,0 +1,21 @@
+package operator
+
+import (
+	"context"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func (c operatorClient) CreateUnstructured(ctx context.Context, namespace string, obj *unstructured.Unstructured, gvr schema.GroupVersionResource) (*unstructured.Unstructured, error) {
+	return c.DynamicClient.Resource(gvr).Namespace(namespace).Create(ctx, obj, v1.CreateOptions{})
+}
+
+func (c operatorClient) GetUnstructured(ctx context.Context, namespace, name string, gvr schema.GroupVersionResource) (*unstructured.Unstructured, error) {
+	return c.DynamicClient.Resource(gvr).Namespace(namespace).Get(ctx, name, v1.GetOptions{})
+}
+
+func (c operatorClient) DeleteUnstructured(ctx context.Context, namespace, name string, gvr schema.GroupVersionResource) error {
+	return c.DynamicClient.Resource(gvr).Namespace(namespace).Delete(ctx, name, v1.DeleteOptions{})
+}

--- a/internal/operator/version.go
+++ b/internal/operator/version.go
@@ -3,7 +3,8 @@ package operator
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "github.com/openshift/api/config/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // GetOpenShiftVersion uses the OpenShift Config clientset to get a ClusterVersion resource which has the
@@ -12,14 +13,8 @@ func (c operatorClient) GetOpenShiftVersion(ctx context.Context) (string, error)
 	// version is the OpenShift version of the cluster
 	var version string
 
-	// OpenShift Config client used to talk with the OpenShift API
-	configClient, err := NewConfigClient()
-	if err != nil {
-		return "", err
-	}
-
-	cversions, err := configClient.ClusterVersions().List(ctx, metav1.ListOptions{})
-	if err != nil {
+	var cversions v1.ClusterVersionList
+	if err := c.Client.List(ctx, &cversions, &client.ListOptions{}); err != nil {
 		version = "0.0.0"
 		return version, err
 	}


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

In order to make the csv.go code testable, a pretty major refactor needed to occur. The clients used needed to be injected in order to make replacement with a fake possible. This now limits the number of places that the client is instantiated.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #216


<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

* Move client creation up into the cmds that use one
* Create the dynamic and olm clients inside the operatorClient
* Add new methods for olm and unstructured to the operator.Client interface
* Simplify the csv.go to remove some unnecessary code
* Add tests for csv.go

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests

