### PR TITLE
Add support for canceling work upon Ctrl-C

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/opdev/opcap/internal/logger"
 	"github.com/spf13/cobra"
@@ -39,14 +38,15 @@ func rootCmd() *cobra.Command {
 
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
-func Execute() {
+func Execute(ctx context.Context) error {
 	cmd := rootCmd()
 
-	err := cmd.ExecuteContext(context.Background())
+	err := cmd.ExecuteContext(ctx)
 	if err != nil {
 		fmt.Fprintf(cmd.ErrOrStderr(), "Opcap tool execution failed: %v\n", err)
-		os.Exit(1)
+		return ctx.Err()
 	}
+	return nil
 }
 
 // kubeConfig return kubernetes cluster config

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/opdev/opcap
 
-go 1.17
+go 1.18
 
 require github.com/spf13/cobra v1.4.0
 

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -9,7 +9,6 @@ import (
 	"github.com/opdev/opcap/internal/operator"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
-	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
 )
 
@@ -182,32 +181,13 @@ func withCustomResources(customResources []map[string]interface{}) auditOption {
 	}
 }
 
-type options struct {
-	Subscription      *operator.SubscriptionData
-	operatorGroupData *operator.OperatorGroupData
-	namespace         string
-	client            operator.Client
-	CsvTimeout        bool
-	csvWaitTime       time.Duration
-	Csv               *v1alpha1.ClusterServiceVersion
-	OcpVersion        string
-	customResources   []map[string]interface{}
-	operands          []unstructured.Unstructured
-}
-
-type auditFn func(context.Context) error
-
 // New returns a function corresponding to a passed in audit plan
-func newAudit(ctx context.Context, auditType string, opts ...auditOption) auditFn {
+func newAudit(ctx context.Context, auditType string, opts ...auditOption) (auditFn, auditCleanupFn) {
 	switch strings.ToLower(auditType) {
 	case "operatorinstall":
 		return operatorInstall(ctx, opts...)
-	case "operatorcleanup":
-		return operatorCleanUp(ctx, opts...)
 	case "operandinstall":
 		return operandInstall(ctx, opts...)
-	case "operandcleanup":
-		return operandCleanUp(ctx, opts...)
 	}
-	return nil
+	return nil, nil
 }

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -13,7 +13,7 @@ import (
 )
 
 // OperandCleanup removes the operand from the OCP cluster in the ca.namespace
-func operandCleanUp(ctx context.Context, opts ...auditOption) auditFn {
+func operandCleanup(ctx context.Context, opts ...auditOption) auditCleanupFn {
 	var options options
 	for _, opt := range opts {
 		err := opt(&options)

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -41,14 +41,16 @@ func extractAlmExamples(ctx context.Context, options *options) error {
 }
 
 // OperandInstall installs the operand from the ALMExamples in the ca.namespace
-func operandInstall(ctx context.Context, opts ...auditOption) auditFn {
+func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCleanupFn) {
 	var options options
 	for _, opt := range opts {
 		err := opt(&options)
 		if err != nil {
 			return func(_ context.Context) error {
-				return fmt.Errorf("option failed: %v", err)
-			}
+					return fmt.Errorf("option failed: %v", err)
+				}, func(_ context.Context) error {
+					return nil
+				}
 		}
 	}
 
@@ -125,5 +127,5 @@ func operandInstall(ctx context.Context, opts ...auditOption) auditFn {
 		}
 
 		return nil
-	}
+	}, operandCleanup(ctx, opts...)
 }

--- a/internal/capability/operator_cleanup.go
+++ b/internal/capability/operator_cleanup.go
@@ -7,7 +7,7 @@ import (
 	"github.com/opdev/opcap/internal/logger"
 )
 
-func operatorCleanUp(ctx context.Context, opts ...auditOption) auditFn {
+func operatorCleanup(ctx context.Context, opts ...auditOption) auditCleanupFn {
 	var options options
 	for _, opt := range opts {
 		err := opt(&options)

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -10,14 +10,17 @@ import (
 	"github.com/opdev/opcap/internal/operator"
 )
 
-func operatorInstall(ctx context.Context, opts ...auditOption) auditFn {
+func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCleanupFn) {
 	var options options
 	for _, opt := range opts {
 		err := opt(&options)
 		if err != nil {
 			return func(_ context.Context) error {
-				return fmt.Errorf("option failed: %v", err)
-			}
+					return fmt.Errorf("option failed: %v", err)
+				},
+				func(_ context.Context) error {
+					return nil
+				}
 		}
 	}
 
@@ -72,5 +75,5 @@ func operatorInstall(ctx context.Context, opts ...auditOption) auditFn {
 		}
 
 		return nil
-	}
+	}, operatorCleanup(ctx, opts...)
 }

--- a/internal/capability/types.go
+++ b/internal/capability/types.go
@@ -1,0 +1,63 @@
+package capability
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/opdev/opcap/internal/operator"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+type options struct {
+	Subscription      *operator.SubscriptionData
+	operatorGroupData *operator.OperatorGroupData
+	namespace         string
+	client            operator.Client
+	CsvTimeout        bool
+	csvWaitTime       time.Duration
+	Csv               *v1alpha1.ClusterServiceVersion
+	OcpVersion        string
+	customResources   []map[string]interface{}
+	operands          []unstructured.Unstructured
+}
+
+type (
+	auditFn        func(context.Context) error
+	auditCleanupFn func(context.Context) error
+)
+
+type Stack[T any] struct {
+	stack *element[T]
+}
+
+type element[T any] struct {
+	previous *element[T]
+	val      T
+}
+
+var StackEmptyError = errors.New("Stack empty")
+
+func (s *Stack[T]) Push(v T) {
+	e := &element[T]{
+		previous: s.stack,
+		val:      v,
+	}
+	s.stack = e
+}
+
+func (s *Stack[T]) Pop() (T, error) {
+	if s.stack == nil {
+		var r T
+		return r, StackEmptyError
+	}
+	e := *s.stack
+	s.stack = e.previous
+
+	return e.val, nil
+}
+
+func (s *Stack[T]) Empty() bool {
+	return s.stack == nil
+}

--- a/internal/capability/types_test.go
+++ b/internal/capability/types_test.go
@@ -1,0 +1,42 @@
+package capability
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Types", func() {
+	Context("Stack", func() {
+		var stack Stack[int]
+
+		BeforeEach(func() {
+			stack = Stack[int]{}
+		})
+		When("a stack is created", func() {
+			It("should be empty", func() {
+				Expect(stack.Empty()).To(BeTrue())
+			})
+		})
+		When("an element is pushed", func() {
+			BeforeEach(func() {
+				stack.Push(10)
+			})
+
+			It("should not be empty", func() {
+				Expect(stack.Empty()).To(BeFalse())
+			})
+			It("should return that element when popped and be empty", func() {
+				e, err := stack.Pop()
+				Expect(err).ToNot(HaveOccurred())
+				Expect(e).To(Equal(10))
+				Expect(stack.Empty()).To(BeTrue())
+			})
+		})
+		When("popping an empty stack", func() {
+			It("should not break", func() {
+				_, err := stack.Pop()
+				Expect(err).To(Equal(StackEmptyError))
+			})
+		})
+	})
+})

--- a/main.go
+++ b/main.go
@@ -1,7 +1,27 @@
 package main
 
-import "github.com/opdev/opcap/cmd"
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/opdev/opcap/cmd"
+)
 
 func main() {
-	cmd.Execute()
+	exitCode := 0
+	defer func() {
+		os.Exit(exitCode)
+	}()
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
+
+	defer stop()
+
+	if err := cmd.Execute(ctx); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		exitCode = 1
+		return
+	}
 }


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
The main() func now looks for interrupt signals, and will propagate the cancel signal down through the context.

It sets up the capability to run cleanup for audits that have been run.

Signed-off-by: Brad P. Crochet <brad@redhat.com>


<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Refers #226

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Add trap of interrupt signals

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
