### PR TITLE
Fix CSVList for the right operator

### DIFF
--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -22,10 +22,11 @@ func extractAlmExamples(ctx context.Context, options *options) error {
 		return err
 	}
 	almExamples := ""
-
-	// map of string interface which consist of ALM examples from the CSVList
-	if len(csvList.Items) > 0 {
-		almExamples = csvList.Items[0].ObjectMeta.Annotations["alm-examples"]
+	for _, csvVal := range csvList.Items {
+		if strings.HasPrefix(csvVal.ObjectMeta.Name, options.operatorGroupData.Name) {
+			// map of string interface which consist of ALM examples from the CSVList
+			almExamples = csvVal.ObjectMeta.Annotations["alm-examples"]
+		}
 	}
 	var almList []map[string]interface{}
 


### PR DESCRIPTION


<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
Signed-off-by: Yuri Sa <yurimsa@gmail.com>

The function extractAlmExamples now iterate through CSVList.Items testing if we are getting values from the right CSV file, avoiding getting values from the first CSV returned from the List.


<!--All PRs required a linked issue. If there is not issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e., "Fixes #101"-->
Refers #258 

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Added iteration through CSVList.Items.
- Added check if we are getting the right values.


<!--Please list any items deprecated by your PR. Feel free to remove this section if unused.-->
## Deprecations (optional)

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests

<!--Please list any external references that might be helpful in understanding your changes.
Feel free to remove this section if unused.-->
## References (optional)