### PR TITLE
Truncate namespace when generated

### DIFF
--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -52,8 +52,18 @@ type capAudit struct {
 	operands []unstructured.Unstructured
 }
 
+func generateNamespace(packageName string, installMode string) string {
+	installModeString := string(installMode)
+	namespaceLength := 63 - len("opcap-") - len(installModeString) - 1
+	return strings.Join([]string{
+		"opcap",
+		packageName[:namespaceLength],
+		installModeString,
+	}, "-")
+}
+
 func newCapAudit(ctx context.Context, c operator.Client, subscription operator.SubscriptionData, auditPlan []string, extraCustomResources []map[string]interface{}) (*capAudit, error) {
-	ns := strings.Join([]string{"opcap", strings.ReplaceAll(subscription.Package, ".", "-"), strings.ToLower(string(subscription.InstallModeType))}, "-")
+	ns := generateNamespace(strings.ReplaceAll(subscription.Package, ".", "-"), strings.ToLower(string(subscription.InstallModeType)))
 	operatorGroupName := strings.Join([]string{subscription.Name, subscription.Channel, "group"}, "-")
 
 	ocpVersion, err := c.GetOpenShiftVersion(ctx)

--- a/internal/capability/audit_test.go
+++ b/internal/capability/audit_test.go
@@ -1,0 +1,60 @@
+package capability
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opdev/opcap/internal/operator"
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+var _ = Describe("Audit tests", func() {
+	Context("creating a new audit", func() {
+		It("should truncate the namespace if it is too long", func() {
+			now := metav1.Now()
+			ver := configv1.ClusterVersion{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ClusterVersion",
+					APIVersion: "config.openshift.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "version",
+					Namespace: "testns",
+				},
+				Spec: configv1.ClusterVersionSpec{},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{
+							Version:        "4.11",
+							CompletionTime: &now,
+							StartedTime:    now,
+						},
+					},
+				},
+			}
+			verlist := configv1.ClusterVersionList{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "ClusterVersion",
+					APIVersion: "config.openshift.io/v1",
+				},
+				Items: []configv1.ClusterVersion{ver},
+			}
+			sub := operator.SubscriptionData{
+				Package:         "thisisareallylongnamethatwillneedtobetrimmedandwillotherwisecauseanerror",
+				InstallModeType: v1alpha1.InstallModeTypeAllNamespaces,
+				Name:            "testname",
+				Channel:         "testchannel",
+			}
+			expectedNamespace := "opcap-thisisareallylongnamethatwillneedtobetrimme-allnamespaces"
+			client := operator.NewFakeOpClient([]runtime.Object{&verlist}...)
+			audit, err := newCapAudit(context.Background(), client, sub, []string{}, []map[string]interface{}{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(audit.namespace).To(Equal(expectedNamespace))
+			Expect(len(audit.namespace)).To(Equal(63))
+		})
+	})
+})


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

Namespaces cannot be over 63 characters. Some package names are long enough that when "opcap-" and the install mode are added, the namespace if no longer valid.

Fixes #271

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

* Add unit test for audit namespace
* Add fake client
* Add namespace generator function

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests

