### PR TITLE
Add check on package name size before cutting slice

### DIFF
--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -53,10 +53,16 @@ type capAudit struct {
 
 func generateNamespace(packageName string, installMode string) string {
 	installModeString := string(installMode)
-	namespaceLength := 63 - len("opcap-") - len(installModeString) - 1
+
+	packageNameMaxLength := 63 - len("opcap-") - len(installModeString) - 1
+
+	if len(packageName) > packageNameMaxLength {
+		packageName = packageName[:packageNameMaxLength]
+	}
+
 	return strings.Join([]string{
 		"opcap",
-		packageName[:namespaceLength],
+		packageName,
 		installModeString,
 	}, "-")
 }


### PR DESCRIPTION
Signed-off-by: acmenezes <adcmenezes@gmail.com>

<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
This is for slice out of range panic happening on audit.go line 59 due to not checking the size of package names.

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #288  

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Added if clause checking package name sizes before sub slicing them. That prevents out of range errors when the package name is too small.

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests

<!--Please list any external references that might be helpful in understanding your changes.
Feel free to remove this section if unused.-->
## References (optional)