### PR TITLE
get latest version instead of looping through history

### DIFF
--- a/internal/capability/audit_test.go
+++ b/internal/capability/audit_test.go
@@ -22,8 +22,7 @@ var _ = Describe("Audit tests", func() {
 					APIVersion: "config.openshift.io/v1",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "version",
-					Namespace: "testns",
+					Name: "version",
 				},
 				Spec: configv1.ClusterVersionSpec{},
 				Status: configv1.ClusterVersionStatus{
@@ -36,13 +35,6 @@ var _ = Describe("Audit tests", func() {
 					},
 				},
 			}
-			verlist := configv1.ClusterVersionList{
-				TypeMeta: metav1.TypeMeta{
-					Kind:       "ClusterVersion",
-					APIVersion: "config.openshift.io/v1",
-				},
-				Items: []configv1.ClusterVersion{ver},
-			}
 			sub := operator.SubscriptionData{
 				Package:         "thisisareallylongnamethatwillneedtobetrimmedandwillotherwisecauseanerror",
 				InstallModeType: v1alpha1.InstallModeTypeAllNamespaces,
@@ -50,7 +42,7 @@ var _ = Describe("Audit tests", func() {
 				Channel:         "testchannel",
 			}
 			expectedNamespace := "opcap-thisisareallylongnamethatwillneedtobetrimme-allnamespaces"
-			client := operator.NewFakeOpClient([]runtime.Object{&verlist}...)
+			client := operator.NewFakeOpClient([]runtime.Object{&ver}...)
 			audit, err := newCapAudit(context.Background(), client, sub, []string{}, []map[string]interface{}{})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(audit.namespace).To(Equal(expectedNamespace))

--- a/internal/operator/version.go
+++ b/internal/operator/version.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"context"
 
-	v1 "github.com/openshift/api/config/v1"
+	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -12,19 +12,18 @@ import (
 func (c operatorClient) GetOpenShiftVersion(ctx context.Context) (string, error) {
 	// version is the OpenShift version of the cluster
 	var version string
-
-	var cversions v1.ClusterVersionList
-	if err := c.Client.List(ctx, &cversions, &client.ListOptions{}); err != nil {
+	// The current version of the cluster is represented in the obj named version
+	objKey := client.ObjectKey{
+		Name: "version",
+	}
+	clusterVersion := configv1.ClusterVersion{}
+	if err := c.Client.Get(ctx, objKey, &clusterVersion); err != nil {
 		version = "0.0.0"
 		return version, err
 	}
-
-	for _, cversion := range cversions.Items {
-		histories := cversion.Status.History
-		for _, history := range histories {
-			version = history.Version
-		}
-	}
+	// History is ordered by recency per `oc explain clusterversion.status.history`
+	// The newest update is first in the list.
+	version = clusterVersion.Status.History[0].Version
 
 	return version, nil
 }

--- a/internal/operator/version_test.go
+++ b/internal/operator/version_test.go
@@ -1,0 +1,61 @@
+package operator
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	configv1 "github.com/openshift/api/config/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+var _ = Describe("Version", func() {
+	var operatorClient operatorClient
+	Context("GetVersion", func() {
+		BeforeEach(func() {
+			scheme := runtime.NewScheme()
+			configv1.AddToScheme(scheme)
+			// test data
+			version := configv1.ClusterVersion{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "config.openshift.io/v1",
+					Kind:       "ClusterVersion",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "version",
+				},
+				Status: configv1.ClusterVersionStatus{
+					History: []configv1.UpdateHistory{
+						{Version: "4.10.34"},
+						{Version: "4.9.8"},
+					},
+				},
+			}
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(&version).Build()
+			operatorClient.Client = client
+		})
+		When("getting openshift version", func() {
+			It("should succeed", func() {
+				version, err := operatorClient.GetOpenShiftVersion(context.TODO())
+				Expect(err).ToNot(HaveOccurred())
+				Expect(version).To(Equal("4.10.34"))
+			})
+		})
+	})
+	Context("VersionNotFound", func() {
+		BeforeEach(func() {
+			scheme := runtime.NewScheme()
+			configv1.AddToScheme(scheme)
+			client := fake.NewClientBuilder().WithScheme(scheme).WithObjects().Build()
+			operatorClient.Client = client
+		})
+		When("there is no version obj", func() {
+			It("should error", func() {
+				_, err := operatorClient.GetOpenShiftVersion(context.TODO())
+				Expect(err).To(HaveOccurred())
+			})
+		})
+	})
+})


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
Currently GetOpenShiftVersion lists and loops through the history of OpenShift versions in the cluster. This is unnecessary as only the latest version is relevant. This PR removes the looping logic and relies on fetching the ClusterVersion object named "version" and printing the first entry in the history list which is ordered to have the latest version in OpenShift per `oc explain clusterversion.status.history`

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #273 

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Removed loop to determine oc version
- Added test

<!--Please list any items deprecated by your PR. Feel free to remove this section if unused.-->
## Deprecations (optional)

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests

<!--Please list any external references that might be helpful in understanding your changes.
Feel free to remove this section if unused.-->
## References (optional)