### PR TITLE
Remove resources as the audits are done

### DIFF
--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -227,6 +227,9 @@ func (ca *CapAuditor) RunAudits(ctx context.Context) error {
 				break
 			}
 		}
+
+		// Perform the cleanups now for this audit
+		ca.cleanup(ctx, &cleanups)
 	}
 	return nil
 }


### PR DESCRIPTION

<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
Instead of waiting til the end of the complete run, this will enable deleting creating namespaces as each operator is completed.

Signed-off-by: Brad P. Crochet <brad@redhat.com>


<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #291

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Call cleanup explicitly for each outer loop of audit items

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
