### PR TITLE
Refactor the 'package list' command to 'list packages'

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,14 +19,14 @@ func errorPreRunE(message string, err error) func(cmd *cobra.Command, args []str
 	}
 }
 
-func packageCmd() *cobra.Command {
+func listCmd() *cobra.Command {
 	// Run is empty. Otherwise, on an error, it would not be marked
 	// as Runnable, which would not print out the usage/help.
 	// TODO: Can we add the subcommand before the client is established?
 	cmd := cobra.Command{
-		Use:   "package",
-		Short: "Package commands",
-		Long:  "Commands that will operate on package manifests",
+		Use:   "list",
+		Short: "List commands",
+		Long:  "Commands that will list various object",
 		Run:   func(cmd *cobra.Command, args []string) {},
 	}
 
@@ -48,7 +48,7 @@ func packageCmd() *cobra.Command {
 		return &cmd
 	}
 
-	cmd.AddCommand(packageListCmd(c))
+	cmd.AddCommand(listPackagesCmd(c))
 
 	// We have the subcommand now, so make Run nil to trigger the usage/help
 	// properly when no other subcommands are present on the CLI.

--- a/cmd/list_packages.go
+++ b/cmd/list_packages.go
@@ -16,9 +16,9 @@ var packageListFlags struct {
 	Packages      []string
 }
 
-func packageListCmd(client client.Client) *cobra.Command {
+func listPackagesCmd(client client.Client) *cobra.Command {
 	cmd := cobra.Command{
-		Use:   "list",
+		Use:   "packages",
 		Short: "List the package manifests for a given CatalogSource and Namespace",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			packageManifestList, err := packages.List(cmd.Context(), client, packageListFlags.CatalogSource, packageListFlags.Packages)

--- a/cmd/list_packages_test.go
+++ b/cmd/list_packages_test.go
@@ -36,7 +36,7 @@ var _ = Describe("PackageList Cmd", func() {
 				}
 				fakeClientBuilder := fake.NewClientBuilder().WithScheme(scheme)
 				fakeClient := fakeClientBuilder.WithObjects([]client.Object{packageManifest}...).Build()
-				output, err := executeCommand(packageListCmd(fakeClient), []string{"--catalogsource=test-catalogsource"}...)
+				output, err := executeCommand(listPackagesCmd(fakeClient), []string{"--catalogsource=test-catalogsource"}...)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(output).To(MatchRegexp("test\\s+test-catalogsource\\s+test-catalogsourcename"))
 			})
@@ -46,7 +46,7 @@ var _ = Describe("PackageList Cmd", func() {
 				By("removing the scheme", func() {
 					builder := fake.NewClientBuilder()
 					fakeClient := builder.WithLists().Build()
-					_, err := executeCommand(packageListCmd(fakeClient))
+					_, err := executeCommand(listPackagesCmd(fakeClient))
 					Expect(err).To(HaveOccurred())
 				})
 			})

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -14,7 +14,7 @@ var _ = Describe("Package CMD", func() {
 	})
 	When("Initializing the command", func() {
 		It("should fail", func() {
-			cmd := packageCmd()
+			cmd := listCmd()
 			// If PreRunE && Run are not nil, there was a failure
 			Expect(cmd.PreRunE).ToNot(BeNil())
 			Expect(cmd.Run).ToNot(BeNil())
@@ -22,7 +22,7 @@ var _ = Describe("Package CMD", func() {
 	})
 	When("Executing the command", func() {
 		It("should fail", func() {
-			out, err := executeCommand(packageCmd())
+			out, err := executeCommand(listCmd())
 			Expect(err).To(HaveOccurred())
 			Expect(out).To(ContainSubstring("unable to establish kubeconfig"))
 		})

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -31,7 +31,7 @@ func rootCmd() *cobra.Command {
 	cmd.AddCommand(uploadCmd())
 	cmd.AddCommand(versionCmd())
 	cmd.AddCommand(checkCmd())
-	cmd.AddCommand(packageCmd())
+	cmd.AddCommand(listCmd())
 
 	return &cmd
 }


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

opcap will have multiple list commands. Instead of proliferating a bunch of 'object list' commands, this patch instead makes it to be 'list objects'.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #297

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- rename 'package list' to 'list packages'

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
