### PR TITLE
Add an option to pass an afero filesystem to audits

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -6,6 +6,7 @@ import (
 	"github.com/opdev/opcap/internal/capability"
 	"github.com/opdev/opcap/internal/operator"
 
+	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
 )
 
@@ -56,8 +57,10 @@ and/or users.`,
 				}
 			}
 
+			fs := afero.NewOsFs()
+
 			// run all dynamically built audits in the auditor workqueue
-			if err := capAuditor.RunAudits(cmd.Context()); err != nil {
+			if err := capAuditor.RunAudits(cmd.Context(), fs); err != nil {
 				return err
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -104,6 +104,7 @@ require (
 
 require (
 	github.com/onsi/gomega v1.20.2
+	github.com/spf13/afero v1.6.0
 	go.uber.org/zap v1.23.0
 	k8s.io/apiextensions-apiserver v0.24.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1004,6 +1004,7 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
+github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cast v1.3.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/opdev/opcap/internal/operator"
+	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
@@ -183,6 +184,14 @@ func withOcpVersion(ocpVersion string) auditOption {
 func withCustomResources(customResources []map[string]interface{}) auditOption {
 	return func(options *options) error {
 		options.customResources = customResources
+		return nil
+	}
+}
+
+// withFilesystem adds a filesystem to be used for writing files
+func withFilesystem(fs afero.Fs) auditOption {
+	return func(options *options) error {
+		options.fs = fs
 		return nil
 	}
 }

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
+	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
@@ -191,7 +192,7 @@ func (ca *CapAuditor) cleanup(ctx context.Context, stack *Stack[auditCleanupFn])
 }
 
 // RunAudits executes all selected functions in order for a given audit at a time
-func (ca *CapAuditor) RunAudits(ctx context.Context) error {
+func (ca *CapAuditor) RunAudits(ctx context.Context, fs afero.Fs) error {
 	cleanups := Stack[auditCleanupFn]{}
 	defer ca.cleanup(ctx, &cleanups)
 
@@ -215,6 +216,7 @@ func (ca *CapAuditor) RunAudits(ctx context.Context) error {
 				withSubscription(&audit.subscription),
 				withTimeout(int(audit.csvWaitTime)),
 				withCustomResources(audit.customResources),
+				withFilesystem(fs),
 			)
 			if auditFn == nil {
 				logger.Errorf("invalid audit plan specified: %s", function)

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -90,7 +90,7 @@ func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCle
 			options.operands = append(options.operands, *obj)
 		}
 
-		file, err := os.OpenFile("operand_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		file, err := options.fs.OpenFile("operand_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return err
 		}

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -60,7 +60,7 @@ func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCl
 		}
 		options.Csv = resultCSV
 
-		file, err := os.OpenFile("operator_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+		file, err := options.fs.OpenFile("operator_install_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 		if err != nil {
 			return err
 		}

--- a/internal/capability/types.go
+++ b/internal/capability/types.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/opdev/opcap/internal/operator"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
+	"github.com/spf13/afero"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -21,6 +22,7 @@ type options struct {
 	OcpVersion        string
 	customResources   []map[string]interface{}
 	operands          []unstructured.Unstructured
+	fs                afero.Fs
 }
 
 type (


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

To make audits easier to test, pass in a filesystem to be used for writing files. This will allow the filesystem to be changed out with for instance a memmap filesystem so it can be thrown away after a test is run without having to write actual files to the physical filesystem.

Signed-off-by: Brad P. Crochet <brad@redhat.com>

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #298

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Add an option for passing a filesystem into audits
- Create an OS filesystem in the check command to pass down via RunAudits

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
