### PR TITLE
Add an option to pass an io.Writer to audits

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -60,7 +60,7 @@ and/or users.`,
 			fs := afero.NewOsFs()
 
 			// run all dynamically built audits in the auditor workqueue
-			if err := capAuditor.RunAudits(cmd.Context(), fs); err != nil {
+			if err := capAuditor.RunAudits(cmd.Context(), fs, cmd.OutOrStdout()); err != nil {
 				return err
 			}
 

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -3,6 +3,7 @@ package capability
 import (
 	"context"
 	"fmt"
+	"io"
 	"strings"
 	"time"
 
@@ -192,6 +193,17 @@ func withCustomResources(customResources []map[string]interface{}) auditOption {
 func withFilesystem(fs afero.Fs) auditOption {
 	return func(options *options) error {
 		options.fs = fs
+		return nil
+	}
+}
+
+// withReportWriter adds an io.Writer to be used for outputing the test reports
+func withReportWriter(w io.Writer) auditOption {
+	return func(options *options) error {
+		if w == nil {
+			return fmt.Errorf("report writer cannot be nil")
+		}
+		options.reportWriter = w
 		return nil
 	}
 }

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -192,7 +193,7 @@ func (ca *CapAuditor) cleanup(ctx context.Context, stack *Stack[auditCleanupFn])
 }
 
 // RunAudits executes all selected functions in order for a given audit at a time
-func (ca *CapAuditor) RunAudits(ctx context.Context, fs afero.Fs) error {
+func (ca *CapAuditor) RunAudits(ctx context.Context, fs afero.Fs, reportWriter io.Writer) error {
 	cleanups := Stack[auditCleanupFn]{}
 	defer ca.cleanup(ctx, &cleanups)
 
@@ -217,6 +218,7 @@ func (ca *CapAuditor) RunAudits(ctx context.Context, fs afero.Fs) error {
 				withTimeout(int(audit.csvWaitTime)),
 				withCustomResources(audit.customResources),
 				withFilesystem(fs),
+				withReportWriter(reportWriter),
 			)
 			if auditFn == nil {
 				logger.Errorf("invalid audit plan specified: %s", function)

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -108,7 +108,7 @@ func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCle
 			return fmt.Errorf("could not generate operand install JSON report: %v", err)
 		}
 
-		err = report.OperandInstallTextReport(os.Stdout, report.TemplateData{
+		err = report.OperandInstallTextReport(options.reportWriter, report.TemplateData{
 			CustomResources: options.customResources,
 			OcpVersion:      options.ocpVersion,
 			Subscription:    *options.subscription,

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -77,7 +77,7 @@ func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCl
 			return fmt.Errorf("could not generate operator install JSON report: %v", err)
 		}
 
-		err = report.OperatorInstallTextReport(os.Stdout, report.TemplateData{
+		err = report.OperatorInstallTextReport(options.reportWriter, report.TemplateData{
 			OcpVersion:   options.ocpVersion,
 			Subscription: *options.subscription,
 			Csv:          options.csv,

--- a/internal/capability/types.go
+++ b/internal/capability/types.go
@@ -3,6 +3,7 @@ package capability
 import (
 	"context"
 	"errors"
+	"io"
 	"time"
 
 	"github.com/opdev/opcap/internal/operator"
@@ -23,6 +24,7 @@ type options struct {
 	customResources   []map[string]interface{}
 	operands          []unstructured.Unstructured
 	fs                afero.Fs
+	reportWriter      io.Writer
 }
 
 type (


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
To make audits easier to test, pass in an io.Writer to be used for writing the text reports. This will allow the writer to be changed out with a buffer for instance so it can be validated in a test without writing directly to stdout.

Signed-off-by: Brad P. Crochet <brad@redhat.com>


<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #299

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Add an option for passing an io.Writer to audits
- Pass the cmd.OutOrStdout to RunAudits 

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
