### PR TITLE
Add operator_install tests

### DIFF
--- a/internal/capability/operator_install_test.go
+++ b/internal/capability/operator_install_test.go
@@ -1,0 +1,96 @@
+package capability
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opdev/opcap/internal/operator"
+	v1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Operator install tests", func() {
+	var csv v1alpha1.ClusterServiceVersion
+	var fakeClient operator.Client
+	var operatorGroupData operator.OperatorGroupData
+	var subscription operator.SubscriptionData
+	var customResources []map[string]interface{}
+	BeforeEach(func() {
+		// Set up and clean up temporary directory for CSV created in operator_install
+		tmpDir, err := os.MkdirTemp("", "operator-install-*")
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(os.RemoveAll, tmpDir)
+		cwd, err := os.Getwd()
+		Expect(err).ToNot(HaveOccurred())
+		DeferCleanup(os.Chdir, cwd)
+		os.Chdir(tmpDir)
+
+		csv = v1alpha1.ClusterServiceVersion{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "testcsv",
+				Namespace: "testns",
+			},
+			Status: v1alpha1.ClusterServiceVersionStatus{
+				Phase: v1alpha1.CSVPhaseSucceeded,
+			},
+		}
+
+		fakeClient = operator.NewFakeOpClient(&csv)
+
+		operatorGroupData = operator.OperatorGroupData{
+			Name:             "testog",
+			TargetNamespaces: []string{"default", "testns"},
+		}
+
+		subscription = operator.SubscriptionData{
+			Name:            "testsub",
+			Channel:         "test",
+			InstallModeType: v1alpha1.InstallModeTypeAllNamespaces,
+			Package:         "testpackage",
+			CatalogSource:   "testcatalog",
+		}
+
+		customResources = []map[string]interface{}{
+			{
+				"kind": "testkind",
+				"metadata": map[string]interface{}{
+					"name": "testname",
+				},
+			},
+		}
+	})
+	Context("creating a new operator install audit", func() {
+		When("given valid options", func() {
+			It("should return functional auditFn and auditCleanupFn", func() {
+				auditFn, auditCleanupFn := operatorInstall(context.TODO(),
+					withClient(fakeClient),
+					withNamespace("testingThings"),
+					withOperatorGroupData(&operatorGroupData),
+					withSubscription(&subscription),
+					withTimeout(1),
+					withCustomResources(customResources),
+				)
+				ctx := context.TODO()
+				err := auditFn(ctx)
+				Expect(err).To(Not(HaveOccurred()))
+				Expect(auditCleanupFn(context.TODO())).To(Succeed())
+			})
+		})
+		When("given an invalid option to add", func() {
+			It("should return an auditFn that gives an error and an auditCleanupFn that returns nil", func() {
+				auditFn, auditCleanupFn := operatorInstall(context.TODO(),
+					withClient(fakeClient),
+					withNamespace(""),
+					withOperatorGroupData(&operatorGroupData),
+					withSubscription(&subscription),
+					withTimeout(1),
+					withCustomResources(customResources),
+				)
+				Expect(auditFn(context.TODO())).ToNot(Succeed())
+				Expect(auditCleanupFn(context.TODO())).To(BeNil())
+			})
+		})
+	})
+})

--- a/internal/capability/suite_test.go
+++ b/internal/capability/suite_test.go
@@ -5,9 +5,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/opdev/opcap/internal/logger"
 )
 
 func TestCapability(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operator Suite")
 }
+
+var _ = BeforeSuite(func() {
+	Expect(logger.InitLogger("debug")).To(Succeed())
+})


### PR DESCRIPTION
Closes [#279]

<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
Adds operator_install_test.go which can be tested the same way as other go unit tests.

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #279 

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Added operator_install_test.go
- Added logger initialization to capability/suite_test.go 

<!--Please list any items deprecated by your PR. Feel free to remove this section if unused.-->

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests