### PR TITLE
Refactor auditor to use functional options

### DIFF
--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -118,12 +118,9 @@ func getTargetNamespaces(s operator.SubscriptionData, namespace string) []string
 	return []string{}
 }
 
-// auditOption is the function type for passing an option to an audit
-type auditOption func(options *options) error
-
 // WithSubscription adds a subscription object to the audit
 func withSubscription(subscription *operator.SubscriptionData) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		if subscription == nil {
 			return fmt.Errorf("subscription data cannot be nil")
 		}
@@ -134,7 +131,7 @@ func withSubscription(subscription *operator.SubscriptionData) auditOption {
 
 // WithOperatorGroupData adds an operatorgroupdata objec to the audit
 func withOperatorGroupData(operatorGroupData *operator.OperatorGroupData) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		if operatorGroupData == nil {
 			return fmt.Errorf("operatorgroupdata cannot be nil")
 		}
@@ -145,7 +142,7 @@ func withOperatorGroupData(operatorGroupData *operator.OperatorGroupData) auditO
 
 // WithNamespace adds a namespace for the audit
 func withNamespace(namespace string) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		if namespace == "" {
 			return fmt.Errorf("namespace cannot be empty")
 		}
@@ -156,7 +153,7 @@ func withNamespace(namespace string) auditOption {
 
 // WithClient adds a client to the audit
 func withClient(client operator.Client) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		if client == nil {
 			return fmt.Errorf("client cannot be nil")
 		}
@@ -166,16 +163,16 @@ func withClient(client operator.Client) auditOption {
 }
 
 // WithTimeout adds a timeout duration to the audit
-func withTimeout(csvWaitTime int) auditOption {
-	return func(options *options) error {
-		options.csvWaitTime = time.Duration(csvWaitTime)
+func withTimeout(csvWaitTime time.Duration) auditOption {
+	return func(options *auditOptions) error {
+		options.csvWaitTime = csvWaitTime
 		return nil
 	}
 }
 
 // WithOcpVersion adds the OCP version to the audit
 func withOcpVersion(ocpVersion string) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		options.ocpVersion = ocpVersion
 		return nil
 	}
@@ -183,7 +180,7 @@ func withOcpVersion(ocpVersion string) auditOption {
 
 // withCustomResources adds existing Custom Resources to the audit
 func withCustomResources(customResources []map[string]interface{}) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		options.customResources = customResources
 		return nil
 	}
@@ -191,7 +188,7 @@ func withCustomResources(customResources []map[string]interface{}) auditOption {
 
 // withFilesystem adds a filesystem to be used for writing files
 func withFilesystem(fs afero.Fs) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		options.fs = fs
 		return nil
 	}
@@ -199,7 +196,7 @@ func withFilesystem(fs afero.Fs) auditOption {
 
 // withReportWriter adds an io.Writer to be used for outputing the test reports
 func withReportWriter(w io.Writer) auditOption {
-	return func(options *options) error {
+	return func(options *auditOptions) error {
 		if w == nil {
 			return fmt.Errorf("report writer cannot be nil")
 		}

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/opdev/opcap/internal/logger"
 	"github.com/opdev/opcap/internal/operator"
@@ -16,32 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-// capAuditor implements Auditor
-type CapAuditor struct {
-	// AuditPlan holds the tests that should be run during an audit
-	AuditPlan []string
-
-	// CatalogSource may be built-in OLM or custom
-	CatalogSource string
-	// CatalogSourceNamespace will be openshift-marketplace or custom
-	CatalogSourceNamespace string
-
-	// Packages is a subset of packages to be tested from a catalogSource
-	Packages []string
-
-	// WorkQueue holds capAudits in a buffered channel in order to execute them
-	WorkQueue chan capAudit
-
-	// AllInstallModes will test all install modes supported by an operator
-	AllInstallModes bool
-
-	// extraCustomResources associates packages to a list of Custom Resources (in addition to ALMExamples)
-	// to be audited by the OperandInstall AuditPlan.
-	extraCustomResources map[string]interface{}
-
-	// OpCapClient is the main OpenShift client interface
-	OpCapClient operator.Client
-}
+type customResources = map[string][]map[string]interface{}
 
 // ExtraCRDirectory scans the provided directory and populates the extraCustomResources field.
 // Is is expected that the extraCRDirectory posesses subdirectories. Manifest files are present in each subdirectory.
@@ -56,16 +31,16 @@ type CapAuditor struct {
 //	   ├── manifest_file1.json
 //
 //     └── manifest_file2.yaml
-func (ca *CapAuditor) ExtraCRDirectory(extraCRDirectory string) error {
-	logger.Debugw("scaning for extra Custom Resources", "extra CR directory", extraCRDirectory)
-	extraCustomResources := map[string]interface{}{} // maps packages to a list of CR
+func extraCRDirectory(ctx context.Context, options *auditorOptions) (customResources, error) {
+	logger.Debugw("scaning for extra Custom Resources", "extra CR directory", options.extraCustomResources)
+	extraCustomResources := customResources{} // maps packages to a list of CR
 
-	extraCRDirectoryAbsolutePath, err := filepath.Abs(extraCRDirectory)
+	extraCRDirectoryAbsolutePath, err := filepath.Abs(options.extraCustomResources)
 	if err != nil {
-		return fmt.Errorf("could not get absolute path from %s: %v", extraCRDirectory, err)
+		return nil, fmt.Errorf("could not get absolute path from %s: %v", options.extraCustomResources, err)
 	}
 
-	err = filepath.WalkDir(extraCRDirectoryAbsolutePath, func(path string, d fs.DirEntry, err error) error {
+	err = afero.Walk(options.fs, extraCRDirectoryAbsolutePath, func(path string, d fs.FileInfo, err error) error {
 		if err != nil && path == extraCRDirectoryAbsolutePath {
 			// Error reading the root directory, exit and return the error
 			return err
@@ -75,7 +50,7 @@ func (ca *CapAuditor) ExtraCRDirectory(extraCRDirectory string) error {
 			manifestFilePath := path
 			// Checking that the manifest file is placed in a subdirectory
 			if len(strings.Split(manifestFilePath, "/")) != len(strings.Split(extraCRDirectoryAbsolutePath, "/"))+2 {
-				logger.Errorf("Error handling manifest file %s. File should be placed in a subdirectory of %s", manifestFilePath, extraCRDirectory)
+				logger.Errorf("Error handling manifest file %s. File should be placed in a subdirectory of %s", manifestFilePath, options.extraCustomResources)
 				return nil // continue
 			}
 
@@ -85,7 +60,7 @@ func (ca *CapAuditor) ExtraCRDirectory(extraCRDirectory string) error {
 			logger.Debugw("adding Custom Resource", "source manifest file", manifestFilePath, "package", packageName)
 
 			// Get manifest file content
-			manifestBytes, err := os.ReadFile(manifestFilePath)
+			manifestBytes, err := afero.ReadFile(options.fs, manifestFilePath)
 			if err != nil {
 				logger.Errorf("Error reading file %s: %v", manifestFilePath, err)
 				return nil // continue
@@ -106,7 +81,7 @@ func (ca *CapAuditor) ExtraCRDirectory(extraCRDirectory string) error {
 			// Add the Custom Resource to the list of extra Custom Resource for this package
 			var customResourceManifests []map[string]interface{}
 			if _, packageKeyPresent := extraCustomResources[packageName]; packageKeyPresent {
-				customResourceManifests = extraCustomResources[packageName].([]map[string]interface{})
+				customResourceManifests = extraCustomResources[packageName]
 			}
 			customResourceManifests = append(customResourceManifests, manifest)
 
@@ -117,32 +92,30 @@ func (ca *CapAuditor) ExtraCRDirectory(extraCRDirectory string) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("could not read directory %s: %v", extraCRDirectory, err)
+		return nil, fmt.Errorf("could not read directory %s: %v", options.extraCustomResources, err)
 	}
 
-	ca.extraCustomResources = extraCustomResources
-
-	return nil
+	return extraCustomResources, nil
 }
 
 // BuildWorkQueueByCatalog fills in the auditor workqueue with all package information found in a specific catalog
-func (ca *CapAuditor) buildWorkQueueByCatalog(ctx context.Context, c operator.Client) error {
+func buildWorkQueueByCatalog(ctx context.Context, options *auditorOptions, extraCustomResources customResources) error {
 	// Getting subscription data form the package manifests available in the selected catalog
-	subscriptions, err := c.GetSubscriptionData(ctx, ca.CatalogSource, ca.CatalogSourceNamespace, ca.Packages)
+	subscriptions, err := options.opCapClient.GetSubscriptionData(ctx, options.catalogSource, options.catalogSourceNamespace, options.packages)
 	if err != nil {
-		return fmt.Errorf("could not get bundles from CatalogSource: %s: %v", ca.CatalogSource, err)
+		return fmt.Errorf("could not get bundles from CatalogSource: %s: %v", options.catalogSource, err)
 	}
 
 	// build workqueue as buffered channel based subscriptionData list size
-	ca.WorkQueue = make(chan capAudit, len(subscriptions))
-	defer close(ca.WorkQueue)
+	options.workQueue = make(chan capAudit, len(subscriptions))
+	defer close(options.workQueue)
 
 	// packagesToBeAudited is a subset of packages to be tested from a catalogSource
 	var packagesToBeAudited []operator.SubscriptionData
 
 	// get all install modes for all operators in the catalog
 	// and add them to the packagesToBeAudited list
-	if ca.AllInstallModes {
+	if options.allInstallModes {
 		packagesToBeAudited = subscriptions
 	} else {
 		packages := make(map[string]bool)
@@ -158,24 +131,24 @@ func (ca *CapAuditor) buildWorkQueueByCatalog(ctx context.Context, c operator.Cl
 	for _, subscription := range packagesToBeAudited {
 		// Get extra Custom Resources for this subscription, if any
 		mapExtraCustomResources := []map[string]interface{}{}
-		extraCustomResources, ok := ca.extraCustomResources[subscription.Package]
+		extraCustomResources, ok := extraCustomResources[subscription.Package]
 		if ok {
-			mapExtraCustomResources = extraCustomResources.([]map[string]interface{})
+			mapExtraCustomResources = extraCustomResources
 		}
 
-		capAudit, err := newCapAudit(ctx, c, subscription, ca.AuditPlan, mapExtraCustomResources)
+		capAudit, err := newCapAudit(ctx, options.opCapClient, subscription, options.auditPlan, mapExtraCustomResources)
 		if err != nil {
 			return fmt.Errorf("could not build configuration for subscription: %s: %v", subscription.Name, err)
 		}
 
 		// load workqueue with capAudit
-		ca.WorkQueue <- *capAudit
+		options.workQueue <- *capAudit
 	}
 
 	return nil
 }
 
-func (ca *CapAuditor) cleanup(ctx context.Context, stack *Stack[auditCleanupFn]) {
+func cleanup(ctx context.Context, stack *Stack[auditCleanupFn]) {
 	if stack == nil {
 		return
 	}
@@ -193,17 +166,34 @@ func (ca *CapAuditor) cleanup(ctx context.Context, stack *Stack[auditCleanupFn])
 }
 
 // RunAudits executes all selected functions in order for a given audit at a time
-func (ca *CapAuditor) RunAudits(ctx context.Context, fs afero.Fs, reportWriter io.Writer) error {
-	cleanups := Stack[auditCleanupFn]{}
-	defer ca.cleanup(ctx, &cleanups)
+func RunAudits(ctx context.Context, opts ...auditorOption) error {
+	var options auditorOptions
+	for _, opt := range opts {
+		err := opt(&options)
+		if err != nil {
+			return err
+		}
+	}
 
-	err := ca.buildWorkQueueByCatalog(ctx, ca.OpCapClient)
+	cleanups := Stack[auditCleanupFn]{}
+	defer cleanup(ctx, &cleanups)
+
+	var extraCustomResources customResources
+	if options.extraCustomResources != "" {
+		var err error
+		extraCustomResources, err = extraCRDirectory(ctx, &options)
+		if err != nil {
+			return fmt.Errorf("could not read extra custom resources directory: %v", err)
+		}
+	}
+
+	err := buildWorkQueueByCatalog(ctx, &options, extraCustomResources)
 	if err != nil {
 		return fmt.Errorf("unable to build workqueue: %v", err)
 	}
 
 	// read workqueue for audits
-	for audit := range ca.WorkQueue {
+	for audit := range options.workQueue {
 		// read a particular audit's auditPlan for functions
 		// to be executed against operator
 		for _, function := range audit.auditPlan {
@@ -215,10 +205,10 @@ func (ca *CapAuditor) RunAudits(ctx context.Context, fs afero.Fs, reportWriter i
 				withNamespace(audit.namespace),
 				withOperatorGroupData(&audit.operatorGroupData),
 				withSubscription(&audit.subscription),
-				withTimeout(int(audit.csvWaitTime)),
+				withTimeout(options.timeout),
 				withCustomResources(audit.customResources),
-				withFilesystem(fs),
-				withReportWriter(reportWriter),
+				withFilesystem(options.fs),
+				withReportWriter(options.reportWriter),
 			)
 			if auditFn == nil {
 				logger.Errorf("invalid audit plan specified: %s", function)
@@ -233,7 +223,94 @@ func (ca *CapAuditor) RunAudits(ctx context.Context, fs afero.Fs, reportWriter i
 		}
 
 		// Perform the cleanups now for this audit
-		ca.cleanup(ctx, &cleanups)
+		cleanup(ctx, &cleanups)
 	}
 	return nil
+}
+
+func WithAuditPlan(auditPlan []string) auditorOption {
+	return func(options *auditorOptions) error {
+		if len(auditPlan) == 0 {
+			return fmt.Errorf("audit plan cannot be empty")
+		}
+		for _, plan := range auditPlan {
+			if len(plan) == 0 {
+				return fmt.Errorf("audit plan incorrectly specified")
+			}
+		}
+		options.auditPlan = auditPlan
+		return nil
+	}
+}
+
+func WithCatalogSource(catalogSource string) auditorOption {
+	return func(options *auditorOptions) error {
+		options.catalogSource = catalogSource
+		return nil
+	}
+}
+
+func WithCatalogSourceNamespace(catalogSourceNamespace string) auditorOption {
+	return func(options *auditorOptions) error {
+		options.catalogSourceNamespace = catalogSourceNamespace
+		return nil
+	}
+}
+
+func WithPackages(packages []string) auditorOption {
+	return func(options *auditorOptions) error {
+		options.packages = packages
+		return nil
+	}
+}
+
+func WithAllInstallModes(allInstallModes bool) auditorOption {
+	return func(options *auditorOptions) error {
+		options.allInstallModes = allInstallModes
+		return nil
+	}
+}
+
+func WithClient(client operator.Client) auditorOption {
+	return func(options *auditorOptions) error {
+		if client == nil {
+			return fmt.Errorf("client cannot be nil")
+		}
+		options.opCapClient = client
+		return nil
+	}
+}
+
+func WithExtraCRDirectory(extraCRDirectory string) auditorOption {
+	return func(options *auditorOptions) error {
+		options.extraCustomResources = extraCRDirectory
+		return nil
+	}
+}
+
+func WithFilesystem(fs afero.Fs) auditorOption {
+	return func(options *auditorOptions) error {
+		if fs == nil {
+			return fmt.Errorf("filesystem must be specified")
+		}
+		options.fs = fs
+		return nil
+	}
+}
+
+func WithTimeout(timeout time.Duration) auditorOption {
+	return func(options *auditorOptions) error {
+		options.timeout = timeout
+		return nil
+	}
+}
+
+func WithReportWriter(w io.Writer) auditorOption {
+	return func(options *auditorOptions) error {
+		if w == nil {
+			return fmt.Errorf("report writer cannot be nil")
+		}
+		options.reportWriter = w
+		return nil
+	}
 }

--- a/internal/capability/auditor_test.go
+++ b/internal/capability/auditor_test.go
@@ -1,0 +1,232 @@
+package capability
+
+import (
+	"bytes"
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/opdev/opcap/internal/operator"
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
+	"github.com/spf13/afero"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Auditor tests", func() {
+	var options auditorOptions
+	var fs afero.Fs
+	var client operator.Client
+	BeforeEach(func() {
+		fs = afero.NewMemMapFs()
+		packageManifest := &pkgserverv1.PackageManifest{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "v1",
+				Kind:       "packages.operators.coreos.com",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test",
+				Namespace: "testnamespace",
+			},
+			Status: pkgserverv1.PackageManifestStatus{
+				CatalogSource:          "testsource",
+				CatalogSourceNamespace: "testnamespace",
+				Channels: []pkgserverv1.PackageChannel{
+					{
+						Name: "default",
+						CurrentCSVDesc: pkgserverv1.CSVDescription{
+							InstallModes: []operatorv1alpha1.InstallMode{
+								{
+									Type:      operatorv1alpha1.InstallModeTypeOwnNamespace,
+									Supported: true,
+								},
+								{
+									Type:      operatorv1alpha1.InstallModeTypeAllNamespaces,
+									Supported: true,
+								},
+							},
+						},
+					},
+				},
+				DefaultChannel: "default",
+			},
+		}
+		version := configv1.ClusterVersion{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "config.openshift.io/v1",
+				Kind:       "ClusterVersion",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "version",
+			},
+			Status: configv1.ClusterVersionStatus{
+				History: []configv1.UpdateHistory{
+					{Version: "4.10.34"},
+					{Version: "4.9.8"},
+				},
+			},
+		}
+
+		client = operator.NewFakeOpClient(packageManifest, &version)
+		Expect(WithAuditPlan([]string{"operatorinstall"})(&options)).To(Succeed())
+		Expect(WithCatalogSource("testsource")(&options)).To(Succeed())
+		Expect(WithCatalogSourceNamespace("testnamespace")(&options)).To(Succeed())
+		Expect(WithPackages([]string{})(&options)).To(Succeed())
+		Expect(WithAllInstallModes(false)(&options)).To(Succeed())
+		Expect(WithClient(client)(&options)).To(Succeed())
+		Expect(WithExtraCRDirectory("")(&options)).To(Succeed())
+		Expect(WithFilesystem(fs)(&options)).To(Succeed())
+	})
+
+	Context("Auditor functional options", func() {
+		var options *auditorOptions
+
+		BeforeEach(func() {
+			options = &auditorOptions{}
+		})
+
+		Context("audit plan", func() {
+			When("plan is supplied", func() {
+				It("should set audit plan correctly", func() {
+					Expect(WithAuditPlan([]string{"testplan"})(options)).To(Succeed())
+					Expect(options.auditPlan).To(ContainElement("testplan"))
+				})
+			})
+			When("no plan is supplied", func() {
+				It("should throw an error", func() {
+					Expect(WithAuditPlan([]string{})(options)).ToNot(Succeed())
+				})
+			})
+			When("an empty plan is supplied", func() {
+				It("should throw an error", func() {
+					Expect(WithAuditPlan(([]string{""}))(options)).ToNot(Succeed())
+				})
+			})
+		})
+		Context("catalogsource", func() {
+			When("catalogsource is supplied", func() {
+				It("should set catalogsource correctly", func() {
+					Expect(WithCatalogSource("testcs")(options)).To(Succeed())
+					Expect(options.catalogSource).To(Equal("testcs"))
+				})
+			})
+		})
+
+		Context("catalogsource namespace", func() {
+			When("catalogsource namespace is supplied", func() {
+				It("should set catalogsource correctly", func() {
+					Expect(WithCatalogSourceNamespace("testns")(options)).To(Succeed())
+					Expect(options.catalogSourceNamespace).To(Equal("testns"))
+				})
+			})
+		})
+
+		Context("packages", func() {
+			When("packages is supplied", func() {
+				It("should set packages correctly", func() {
+					Expect(WithPackages([]string{"testpackage"})(options)).To(Succeed())
+					Expect(options.packages).To(ContainElement("testpackage"))
+				})
+			})
+		})
+
+		Context("AllInstallModes", func() {
+			When("AllInstallModes is supplied", func() {
+				It("should set allInstallModes correctly", func() {
+					Expect(WithAllInstallModes(true)(options)).To(Succeed())
+					Expect(options.allInstallModes).To(BeTrue())
+				})
+			})
+		})
+
+		Context("Client", func() {
+			When("client is supplied", func() {
+				It("should set client correctly", func() {
+					client := operator.NewFakeOpClient()
+					Expect(WithClient(client)(options)).To(Succeed())
+					Expect(options.opCapClient).To(Equal(client))
+				})
+			})
+			When("client is nil", func() {
+				It("should throw an error", func() {
+					Expect(WithClient(nil)(options)).ToNot(Succeed())
+				})
+			})
+		})
+
+		Context("Extra CR Directory", func() {
+			When("extra CR directory is supplied", func() {
+				It("should set extra CR directory correctly", func() {
+					Expect(WithExtraCRDirectory("/customcrdir")(options)).To(Succeed())
+					Expect(options.extraCustomResources).To(Equal("/customcrdir"))
+				})
+			})
+		})
+
+		Context("Filesystem", func() {
+			When("a filesystem is not supplied", func() {
+				It("should throw an error", func() {
+					Expect(WithFilesystem(nil)(options)).ToNot(Succeed())
+				})
+			})
+		})
+
+		Context("Timeout", func() {
+			When("a timeout is supplied", func() {
+				It("should set the timeout properly", func() {
+					Expect(WithTimeout(time.Second)(options)).To(Succeed())
+					Expect(options.timeout).To(Equal(time.Second))
+				})
+			})
+		})
+	})
+
+	Context("Extra CR Directory", func() {
+		When("extra CR directory is not provided", func() {
+			It("should still succeed", func() {
+				Expect(RunAudits(context.Background(),
+					WithAuditPlan([]string{"operatorinstall"}),
+					WithCatalogSource("testsource"),
+					WithCatalogSourceNamespace("testnamespace"),
+					WithPackages([]string{}),
+					WithAllInstallModes(false),
+					WithClient(client),
+					WithExtraCRDirectory(""),
+					WithFilesystem(fs),
+					WithTimeout(time.Millisecond),
+				)).To(Succeed())
+			})
+		})
+		When("extra CR is provided", func() {
+			When("it is empty", func() {
+				It("should still succeed", func() {
+					Expect(RunAudits(context.Background(),
+						WithAuditPlan([]string{"operatorinstall"}),
+						WithCatalogSource("testsource"),
+						WithCatalogSourceNamespace("testnamespace"),
+						WithPackages([]string{}),
+						WithAllInstallModes(false),
+						WithClient(client),
+						WithExtraCRDirectory("/"),
+						WithFilesystem(fs),
+						WithTimeout(time.Millisecond),
+					)).To(Succeed())
+				})
+			})
+			When("It is not empty", func() {
+				It("should not throw an error", func() {
+					Expect(fs.MkdirAll("/packages/mypackage", 0o755)).To(Succeed())
+					Expect(afero.WriteFile(fs, "/packages/mypackage/manifest.json", bytes.NewBufferString(`{"foo":"bar"}`).Bytes(), 0o644))
+					options := options
+					options.extraCustomResources = "/packages"
+					extraCRs, err := extraCRDirectory(context.TODO(), &options)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(extraCRs).ToNot(BeNil())
+					Expect(extraCRs["mypackage"][0]).To(ContainElement("bar"))
+				})
+			})
+		})
+	})
+})

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -12,7 +12,7 @@ import (
 
 // OperandCleanup removes the operand from the OCP cluster in the ca.namespace
 func operandCleanup(ctx context.Context, opts ...auditOption) auditCleanupFn {
-	var options options
+	var options auditOptions
 	for _, opt := range opts {
 		err := opt(&options)
 		if err != nil {

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -14,7 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
-func extractAlmExamples(ctx context.Context, options *options) error {
+func extractAlmExamples(ctx context.Context, options *auditOptions) error {
 	// gets the list of CSVs present in a particular namespace
 	csvList, err := options.client.ListClusterServiceVersions(ctx, options.namespace)
 	if err != nil {
@@ -41,7 +41,7 @@ func extractAlmExamples(ctx context.Context, options *options) error {
 
 // OperandInstall installs the operand from the ALMExamples in the ca.namespace
 func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCleanupFn) {
-	var options options
+	var options auditOptions
 	for _, opt := range opts {
 		err := opt(&options)
 		if err != nil {

--- a/internal/capability/operator_cleanup.go
+++ b/internal/capability/operator_cleanup.go
@@ -8,7 +8,7 @@ import (
 )
 
 func operatorCleanup(ctx context.Context, opts ...auditOption) auditCleanupFn {
-	var options options
+	var options auditOptions
 	for _, opt := range opts {
 		err := opt(&options)
 		if err != nil {

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -12,7 +12,7 @@ import (
 )
 
 func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCleanupFn) {
-	var options options
+	var options auditOptions
 	for _, opt := range opts {
 		err := opt(&options)
 		if err != nil {

--- a/internal/capability/suite_test.go
+++ b/internal/capability/suite_test.go
@@ -5,9 +5,14 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/opdev/opcap/internal/logger"
 )
 
 func TestCapability(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Operator Suite")
 }
+
+var _ = BeforeSuite(func() {
+	Expect(logger.InitLogger("debug")).To(Succeed())
+})

--- a/internal/capability/types.go
+++ b/internal/capability/types.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-type options struct {
+type auditOptions struct {
 	subscription      *operator.SubscriptionData
 	operatorGroupData *operator.OperatorGroupData
 	namespace         string
@@ -27,9 +27,50 @@ type options struct {
 	reportWriter      io.Writer
 }
 
+type auditorOptions struct {
+	// AuditPlan holds the tests that should be run during an audit
+	auditPlan []string
+
+	// CatalogSource may be built-in OLM or custom
+	catalogSource string
+	// CatalogSourceNamespace will be openshift-marketplace or custom
+	catalogSourceNamespace string
+
+	// Packages is a subset of packages to be tested from a catalogSource
+	packages []string
+
+	// WorkQueue holds capAudits in a buffered channel in order to execute them
+	workQueue chan capAudit
+
+	// AllInstallModes will test all install modes supported by an operator
+	allInstallModes bool
+
+	// extraCustomResources associates packages to a list of Custom Resources (in addition to ALMExamples)
+	// to be audited by the OperandInstall AuditPlan.
+	extraCustomResources string
+
+	// OpCapClient is the main OpenShift client interface
+	opCapClient operator.Client
+
+	// Fs is an afero filesystem used by the auditor
+	fs afero.Fs
+
+	// Timeout is the audit timeout
+	timeout time.Duration
+
+	//  ReportWriter is any io.Writer for the text reports
+	reportWriter io.Writer
+}
+
 type (
 	auditFn        func(context.Context) error
 	auditCleanupFn func(context.Context) error
+
+	// auditOption is the function type for passing an option to an audit
+	auditOption func(options *auditOptions) error
+
+	// auditorOption is the function type for passing an option to RunAudits
+	auditorOption func(options *auditorOptions) error
 )
 
 type Stack[T any] struct {


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
This patch adds functional options to the RunAudits function. In doing so, this removed the need for the capAuditor struct.

Signed-off-by: Brad P. Crochet <brad@redhat.com>


<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #300

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

* Remove capAuditor struct, and make it into the auditorOptions
* What were methods on capAuditor are now just functions
* Add unit tests for auditor
* Use afero for easier testing

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests
