### PR TITLE
Remove client requirement from list command

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -1,58 +1,19 @@
 package cmd
 
 import (
-	"fmt"
-
-	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	"github.com/spf13/cobra"
-	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
-
-func errorPreRunE(message string, err error) func(cmd *cobra.Command, args []string) error {
-	return func(cmd *cobra.Command, args []string) error {
-		if err != nil {
-			return fmt.Errorf("%s: %v", message, err)
-		}
-		return fmt.Errorf("%s", message)
-	}
-}
 
 func listCmd() *cobra.Command {
 	// Run is empty. Otherwise, on an error, it would not be marked
 	// as Runnable, which would not print out the usage/help.
-	// TODO: Can we add the subcommand before the client is established?
 	cmd := cobra.Command{
 		Use:   "list",
 		Short: "List commands",
 		Long:  "Commands that will list various object",
-		Run:   func(cmd *cobra.Command, args []string) {},
 	}
 
-	scheme := runtime.NewScheme()
-	if err := pkgserverv1.AddToScheme(scheme); err != nil {
-		cmd.PreRunE = errorPreRunE("unable to add scheme", err)
-		return &cmd
-	}
-
-	k8sconfig, err := config.GetConfig()
-	if err != nil {
-		cmd.PreRunE = errorPreRunE("unable to establish kubeconfig", nil)
-		return &cmd
-	}
-
-	c, err := client.New(k8sconfig, client.Options{Scheme: scheme})
-	if err != nil {
-		cmd.PreRunE = errorPreRunE("unable to create controller-runtime client: %v", err)
-		return &cmd
-	}
-
-	cmd.AddCommand(listPackagesCmd(c))
-
-	// We have the subcommand now, so make Run nil to trigger the usage/help
-	// properly when no other subcommands are present on the CLI.
-	cmd.Run = nil
+	cmd.AddCommand(listPackagesCmd())
 
 	return &cmd
 }

--- a/cmd/list_packages.go
+++ b/cmd/list_packages.go
@@ -1,14 +1,18 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"strings"
 	"text/tabwriter"
 
 	"github.com/opdev/opcap/internal/packages"
-
+	pkgserverv1 "github.com/operator-framework/operator-lifecycle-manager/pkg/package-server/apis/operators/v1"
 	"github.com/spf13/cobra"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 )
 
 var packageListFlags struct {
@@ -16,27 +20,11 @@ var packageListFlags struct {
 	Packages      []string
 }
 
-func listPackagesCmd(client client.Client) *cobra.Command {
+func listPackagesCmd() *cobra.Command {
 	cmd := cobra.Command{
 		Use:   "packages",
 		Short: "List the package manifests for a given CatalogSource and Namespace",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			packageManifestList, err := packages.List(cmd.Context(), client, packageListFlags.CatalogSource, packageListFlags.Packages)
-			if err != nil {
-				return err
-			}
-
-			headings := "Package Name\tCatalog Source\tCatalog Source Namespace"
-			w := tabwriter.NewWriter(cmd.OutOrStdout(), 0, 0, 2, ' ', 0)
-			fmt.Fprintln(w, headings)
-			for _, packageManifest := range packageManifestList {
-				packageInfo := []string{packageManifest.Name, packageManifest.Status.CatalogSource, packageManifest.Status.CatalogSourceNamespace}
-				fmt.Fprintln(w, strings.Join(packageInfo, "\t"))
-			}
-			w.Flush()
-
-			return nil
-		},
+		RunE:  listPackagesRunE,
 	}
 
 	flags := cmd.Flags()
@@ -46,4 +34,40 @@ func listPackagesCmd(client client.Client) *cobra.Command {
 	flags.StringSliceVar(&packageListFlags.Packages, "packages", []string{}, "a list of package(s) which limits audits and/or other flag(s) output")
 
 	return &cmd
+}
+
+func listPackagesRunE(cmd *cobra.Command, args []string) error {
+	scheme := runtime.NewScheme()
+	if err := pkgserverv1.AddToScheme(scheme); err != nil {
+		return err
+	}
+
+	k8sconfig, err := config.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	c, err := client.New(k8sconfig, client.Options{Scheme: scheme})
+	if err != nil {
+	}
+
+	return listPackages(cmd.Context(), cmd.OutOrStdout(), c)
+}
+
+func listPackages(ctx context.Context, out io.Writer, c client.Client) error {
+	packageManifestList, err := packages.List(ctx, c, packageListFlags.CatalogSource, packageListFlags.Packages)
+	if err != nil {
+		return err
+	}
+
+	headings := "Package Name\tCatalog Source\tCatalog Source Namespace"
+	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, headings)
+	for _, packageManifest := range packageManifestList {
+		packageInfo := []string{packageManifest.Name, packageManifest.Status.CatalogSource, packageManifest.Status.CatalogSourceNamespace}
+		fmt.Fprintln(w, strings.Join(packageInfo, "\t"))
+	}
+	w.Flush()
+
+	return nil
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -1,30 +1,22 @@
 package cmd
 
 import (
-	"os"
-
 	. "github.com/onsi/ginkgo/v2/dsl/core"
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Package CMD", func() {
-	BeforeEach(func() {
-		DeferCleanup(os.Setenv, "KUBECONFIG", os.Getenv("KUBECONFIG"))
-		os.Unsetenv("KUBECONFIG")
-	})
+var _ = Describe("List CMD", func() {
 	When("Initializing the command", func() {
-		It("should fail", func() {
+		It("should not error", func() {
 			cmd := listCmd()
-			// If PreRunE && Run are not nil, there was a failure
-			Expect(cmd.PreRunE).ToNot(BeNil())
-			Expect(cmd.Run).ToNot(BeNil())
+			Expect(cmd.PreRunE).To(BeNil())
+			Expect(cmd.Run).To(BeNil())
 		})
 	})
 	When("Executing the command", func() {
-		It("should fail", func() {
-			out, err := executeCommand(listCmd())
-			Expect(err).To(HaveOccurred())
-			Expect(out).To(ContainSubstring("unable to establish kubeconfig"))
+		It("should not error", func() {
+			_, err := executeCommand(listCmd())
+			Expect(err).ToNot(HaveOccurred())
 		})
 	})
 })


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

The base list command should not create a k8s client. Only the 'list packages' command needs the client. The upcoming 'list bundles' command does not. So, this patch moves the client into the child command instead of the base 'list' command.

Signed-off-by: Brad P. Crochet <brad@redhat.com>


<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #308


<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Move the client creation into the subcommand of 'list packages'

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests

