### PR TITLE
Reorganize and format report templates and JSON

### DIFF
--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -10,47 +10,6 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-const (
-	operatorTextReportTemplate = `
-Operator Install Report
------------------------------------------
-Report Date: {{ now }}
-OpenShift Version: {{ .OcpVersion }}
-Package Name: {{ .Subscription.Package }}
-Channel: {{ .Subscription.Channel }}
-Catalog Source: {{ .Subscription.CatalogSource }}
-Install Mode: {{ .Subscription.InstallModeType }}
-Result: {{ if .CsvTimeout }}timeout{{ else }}{{ .Csv.Status.Phase }}
-Message: {{ .Csv.Status.Message }}
-Reason: {{ .Csv.Status.Reason }}
-{{ end }}
------------------------------------------
-`
-	operatorJsonReportTemplate = `{"level":"info","message":"{{ if .CsvTimeout }}timeout{{ else }}{{ .Csv.Status.Phase }}{{ end }}","package":"{{ .Subscription.Package }}","channel":"{{ .Subscription.Channel }}","installmode":"{{ .Subscription.InstallModeType }}"}{{"\n"}}`
-
-	operandTextReportTemplate = `{{ with $dot := . }}
-{{ range $index, $value := .CustomResources }}
-
-Operand Install Report
------------------------------------------
-Report Date: {{ now }}
-OpenShift Version: {{ $dot.OcpVersion }}
-Package Name: {{ $dot.Subscription.Package }}
-Operand Kind: {{ kind $value }}
-Operand Name: {{ name $value }}
-Operand Creation: {{ if gt $dot.OperandCount 0 }}Succeeded{{ else }}Failed{{ end }}
------------------------------------------
-{{ else }}
-No custom resources
-{{ end }}
-{{ end }}
-`
-
-	operandJsonReportTemplate = `{{with $dot := .}}{{range $index, $value := .CustomResources }}
-{"package":"{{ $dot.Subscription.Package }}","Operand Kind":"{{ kind $value }}","Operand Name":"{{ name $value }}","message":"{{ if gt $dot.OperandCount 0 }}created{{ else }}failed{{ end }}"}
-{{ end }}{{ end }}`
-)
-
 type TemplateData struct {
 	OcpVersion      string
 	Subscription    operator.SubscriptionData

--- a/internal/report/report_operand_templates.go
+++ b/internal/report/report_operand_templates.go
@@ -1,0 +1,24 @@
+package report
+
+const (
+	operandTextReportTemplate = `
+{{ with $dot := . }}
+{{ range $index, $value := .CustomResources }}
+
+Operand Install Report
+-----------------------------------------
+Report Date: {{ now }}
+OpenShift Version: {{ $dot.OcpVersion }}
+Package Name: {{ $dot.Subscription.Package }}
+Operand Kind: {{ kind $value }}
+Operand Name: {{ name $value }}
+Operand Creation: {{ if gt $dot.OperandCount 0 }}Succeeded{{ else }}Failed{{ end }}
+-----------------------------------------
+{{ else }}
+No custom resources
+{{ end }}
+{{ end }}
+`
+
+	operandJsonReportTemplate = `{{with $dot := .}}{{range $index, $value := .CustomResources }}{"package":"{{ $dot.Subscription.Package }}","Operand Kind":"{{ kind $value }}","Operand Name":"{{ name $value }}","message":"{{ if gt $dot.OperandCount 0 }}created{{ else }}failed{{ end }}"}{{ end }}{{ end }}`
+)

--- a/internal/report/report_operator_templates.go
+++ b/internal/report/report_operator_templates.go
@@ -1,0 +1,20 @@
+package report
+
+const (
+	operatorTextReportTemplate = `
+Operator Install Report
+-----------------------------------------
+Report Date: {{ now }}
+OpenShift Version: {{ .OcpVersion }}
+Package Name: {{ .Subscription.Package }}
+Channel: {{ .Subscription.Channel }}
+Catalog Source: {{ .Subscription.CatalogSource }}
+Install Mode: {{ .Subscription.InstallModeType }}
+Result: {{ if .CsvTimeout }}timeout{{ else }}{{ .Csv.Status.Phase }}
+Message: {{ .Csv.Status.Message }}
+Reason: {{ .Csv.Status.Reason }}
+{{ end }}
+-----------------------------------------
+`
+	operatorJsonReportTemplate = `{"level":"info","message":"{{ if .CsvTimeout }}timeout{{ else }}{{ .Csv.Status.Phase }}{{ end }}","package":"{{ .Subscription.Package }}","channel":"{{ .Subscription.Channel }}","installmode":"{{ .Subscription.InstallModeType }}"}{{"\n"}}`
+)


### PR DESCRIPTION
Fixes #306

<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
Moved constants from report.go into separate template files for operator and operand constants. Reformatted the JSON constants to be human-legible.

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #306

<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)

- Moved constants out of report.go
- Created report_operator_templates.go
- Created report_operand_templates.go

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests