### PR TITLE
update go version to 1.19.2 for github CI pipeline

### DIFF
--- a/.github/workflows/build-main.yml
+++ b/.github/workflows/build-main.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.18
+        go-version: 1.19.2
 
     - name: Test
       run: make cover


### PR DESCRIPTION
Signed-off-by: yoza <yoza@redhat.com>

## Description of PR
Update go version for CI pipeline

Fixes #318 

## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests
