### PR TITLE
FIX fields order on list bundles

### DIFF
--- a/cmd/list_bundles.go
+++ b/cmd/list_bundles.go
@@ -75,7 +75,7 @@ func printBundles(bundles []bundle.Bundle, out io.Writer) {
 	w := tabwriter.NewWriter(out, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(w, headings)
 	for _, bundle := range bundles {
-		packageInfo := []string{bundle.StartingCSV, bundle.PackageName, bundle.Channel, bundle.Version, bundle.OcpVersions}
+		packageInfo := []string{bundle.PackageName, bundle.StartingCSV, bundle.Channel, bundle.Version, bundle.OcpVersions}
 		fmt.Fprintln(w, strings.Join(packageInfo, "\t"))
 	}
 	w.Flush()


### PR DESCRIPTION
Signed-off-by: acmenezes <adcmenezes@gmail.com>

## Description of PR
Starting CSV and Package Name are printing in the wrong order. This PR just fixes it.
Fixes #327 

## Changes (required)

- Changed the order Starting CSV and Package Names are being printed.

## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests