### PR TITLE
ADD report on timed out and failed operators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ openshift
 /std*.json
 *report.json
 .DS_Store
+*report.txt

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -84,7 +84,7 @@ func newCapAudit(ctx context.Context, c operator.Client, subscription operator.S
 		namespace:         ns,
 		operatorGroupData: newOperatorGroupData(operatorGroupName, getTargetNamespaces(subscription, ns)),
 		subscription:      subscription,
-		csvWaitTime:       time.Minute,
+		csvWaitTime:       2 * time.Minute,
 		csvTimeout:        false,
 		auditPlan:         auditPlan,
 		customResources:   extraCustomResources,

--- a/internal/capability/debug.go
+++ b/internal/capability/debug.go
@@ -1,0 +1,179 @@
+package capability
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/opdev/opcap/internal/logger"
+	"github.com/opdev/opcap/internal/report"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CollectDebugData(ctx context.Context, options auditOptions) error {
+	c, err := k8sClientset()
+	if err != nil {
+		return fmt.Errorf("couldn't get clientset for operator install debug report: %s", err.Error())
+	}
+
+	// get CSV events
+	events := []report.Event{}
+	if options.csv != nil {
+		EventList, err := EventsByNameAndKind(ctx, c, options.csv.ObjectMeta.Name, "ClusterServiceVersion", options.namespace)
+		if err != nil {
+			return fmt.Errorf("couldn't get eventList for CSV: %s", err.Error())
+		}
+
+		if len(EventList.Items) > 0 {
+			for _, event := range EventList.Items {
+				events = append(events, report.Event{
+					InvolvedObjName:   event.InvolvedObject.Name,
+					InvolvedObjkind:   event.InvolvedObject.Kind,
+					CreationTimestamp: event.CreationTimestamp,
+					Message:           strings.Replace(event.Message, "\"", "", -1),
+					Reason:            event.Reason,
+				})
+			}
+		}
+	}
+	// get pods status and events
+	pods, err := OperatorPods(ctx, c, options.namespace)
+	if err != nil {
+		logger.Infow("couldn't list pods for debug report: %s", err.Error())
+	}
+
+	podEvents := []report.Event{}
+	podLogs := []report.PodLog{}
+	if len(pods.Items) > 0 {
+		for _, pod := range pods.Items {
+
+			EventList, err := EventsByNameAndKind(ctx, c, pod.ObjectMeta.Name, "Pod", options.namespace)
+			if err != nil {
+				return fmt.Errorf("couldn't get eventList for CSV: %s", err.Error())
+			}
+			if len(EventList.Items) > 0 {
+				for _, event := range EventList.Items {
+					podEvents = append(podEvents, report.Event{
+						InvolvedObjName:   event.InvolvedObject.Name,
+						InvolvedObjkind:   event.InvolvedObject.Kind,
+						CreationTimestamp: event.CreationTimestamp,
+						Message:           strings.Replace(event.Message, "\"", "", -1),
+						Reason:            event.Reason,
+					})
+				}
+			}
+			for _, container := range pod.Spec.Containers {
+				log, err := Logs(ctx, c, pod, container.Name)
+				if err != nil {
+					return fmt.Errorf("couldn't get pod logs: %s", err)
+				}
+				podLogs = append(podLogs, report.PodLog{
+					PodName:       pod.ObjectMeta.Name,
+					ContainerName: container.Name,
+					PodLogs:       strings.Replace(log, "\"", "", -1),
+				})
+			}
+		}
+	}
+
+	debugFile, err := options.fs.OpenFile("operator_debug_json_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return err
+	}
+	defer debugFile.Close()
+
+	err = report.DebugJsonReport(debugFile, report.TemplateData{
+		OcpVersion:   options.ocpVersion,
+		Subscription: *options.subscription,
+		Csv:          options.csv,
+		CsvTimeout:   options.csvTimeout,
+		CsvEvents:    events,
+		PodEvents:    podEvents,
+		PodLogs:      podLogs,
+	})
+
+	if err != nil {
+		return fmt.Errorf("could not generate debug JSON report: %v", err)
+	}
+
+	return nil
+}
+
+// kubeConfig return kubernetes cluster config
+func kubeConfig() (*rest.Config, error) {
+	config, err := ctrl.GetConfig()
+	if err != nil {
+		// returned when there is no kubeconfig
+		if errors.Is(err, clientcmd.ErrEmptyConfig) {
+			return nil, fmt.Errorf("please provide kubeconfig before retrying: %v", err)
+		}
+
+		// returned when the kubeconfig has no servers
+		if errors.Is(err, clientcmd.ErrEmptyCluster) {
+			return nil, fmt.Errorf("malformed kubeconfig. Please check before retrying: %v", err)
+		}
+
+		// any other errors getting kubeconfig would be caught here
+		return nil, fmt.Errorf("error getting kubeocnfig. Please check before retrying: %v", err)
+	}
+	return config, nil
+}
+
+func k8sClientset() (*kubernetes.Clientset, error) {
+	config, err := kubeConfig()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get kubeconfig: %s", err)
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't create new clientset: %s", err)
+	}
+	return clientset, nil
+}
+
+func OperatorPods(ctx context.Context, clientset *kubernetes.Clientset, namespace string) (*corev1.PodList, error) {
+	podList, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't list pods for operator: %s", err.Error())
+	}
+
+	return podList, nil
+}
+
+func EventsByNameAndKind(ctx context.Context, clientset *kubernetes.Clientset, name string, kind string, namespace string) (*corev1.EventList, error) {
+	events, err := clientset.CoreV1().Events(namespace).List(ctx, metav1.ListOptions{FieldSelector: "involvedObject.name=" + name, TypeMeta: metav1.TypeMeta{Kind: kind}})
+	if err != nil {
+		return nil, fmt.Errorf("couldn't retrieve events: %s", err)
+	}
+	return events, nil
+}
+
+func Logs(ctx context.Context, clientset *kubernetes.Clientset, pod corev1.Pod, container string) (string, error) {
+	podLogOpts := corev1.PodLogOptions{Container: container}
+	req := clientset.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpts)
+	podLogs, err := req.Stream(ctx)
+	if err != nil {
+		return "", fmt.Errorf("error in opening stream: %s", err)
+	}
+	defer podLogs.Close()
+
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, podLogs)
+	if err != nil {
+		return "", fmt.Errorf("error in copy information from podLogs to buf %s", err)
+	}
+	str := buf.String()
+
+	return str, nil
+}

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -55,6 +55,11 @@ func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCl
 			// If error is timeout than don't log phase but timeout
 			if errors.Is(err, operator.TimeoutError) {
 				options.csvTimeout = true
+				options.csv = resultCSV
+				if err = CollectDebugData(ctx, options); err != nil {
+					return fmt.Errorf("couldn't collect debug data: %s", err)
+				}
+
 			} else {
 				return err
 			}

--- a/internal/capability/types.go
+++ b/internal/capability/types.go
@@ -9,6 +9,7 @@ import (
 	"github.com/opdev/opcap/internal/operator"
 	"github.com/operator-framework/api/pkg/operators/v1alpha1"
 	"github.com/spf13/afero"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -25,6 +26,7 @@ type auditOptions struct {
 	operands          []unstructured.Unstructured
 	fs                afero.Fs
 	reportWriter      io.Writer
+	csvEvents         *corev1.EventList
 }
 
 type auditorOptions struct {

--- a/internal/operator/csv.go
+++ b/internal/operator/csv.go
@@ -54,6 +54,13 @@ func (c operatorClient) GetCompletedCsvWithTimeout(ctx context.Context, namespac
 
 		// if it takes more than delay return with error
 		case <-timeout:
+			csvList := &operatorv1alpha1.ClusterServiceVersionList{}
+			if err = c.Client.List(ctx, csvList, &client.ListOptions{Namespace: namespace}); err != nil {
+				return nil, err
+			}
+			if len(csvList.Items) > 0 {
+				return &csvList.Items[0], TimeoutError
+			}
 			return nil, TimeoutError
 
 		default:

--- a/internal/operator/csv_test.go
+++ b/internal/operator/csv_test.go
@@ -71,10 +71,9 @@ var _ = Describe("CSV", func() {
 		})
 		When("no CSV is updated", func() {
 			It("should timeout", func() {
-				resultCsv, err := client.GetCompletedCsvWithTimeout(context.Background(), "testns", time.Second*2)
+				_, err := client.GetCompletedCsvWithTimeout(context.Background(), "testns", time.Second*2)
 				Expect(err).To(HaveOccurred())
 				Expect(err).To(Equal(TimeoutError))
-				Expect(resultCsv).To(BeNil())
 			})
 		})
 	})

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -2,11 +2,13 @@ package report
 
 import (
 	"io"
+	"strings"
 	"text/template"
 	"time"
 
 	"github.com/opdev/opcap/internal/operator"
 	operatorv1alpha1 "github.com/operator-framework/api/pkg/operators/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -18,14 +20,36 @@ type TemplateData struct {
 	CustomResources []map[string]interface{}
 	OperandCount    int
 	Operands        []unstructured.Unstructured
+	CsvEvents       []Event
+	PodEvents       []Event
+	PodLogs         []PodLog
+}
+
+type Event struct {
+	InvolvedObjName   string
+	InvolvedObjkind   string
+	CreationTimestamp metav1.Time
+	Message           string
+	Reason            string
+}
+
+type PodLog struct {
+	PodName       string
+	ContainerName string
+	PodLogs       string
+}
+
+func replace(input, from, to string) string {
+	return strings.Replace(input, from, to, -1)
 }
 
 func processTemplate(w io.Writer, tmpl string, data interface{}) error {
 	report, err := template.New("report").
 		Funcs(template.FuncMap{
-			"now":  time.Now,
-			"kind": unstructuredKind,
-			"name": unstructuredName,
+			"now":     time.Now,
+			"kind":    unstructuredKind,
+			"name":    unstructuredName,
+			"replace": replace,
 		}).
 		Parse(tmpl)
 	if err != nil {
@@ -61,4 +85,12 @@ func OperandInstallTextReport(w io.Writer, data TemplateData) error {
 
 func OperandInstallJsonReport(w io.Writer, data TemplateData) error {
 	return processTemplate(w, operandJsonReportTemplate, data)
+}
+
+func DebugTextReport(w io.Writer, data TemplateData) error {
+	return processTemplate(w, debugTextDataTemplate, data)
+}
+
+func DebugJsonReport(w io.Writer, data TemplateData) error {
+	return processTemplate(w, debugJSONDataTemplate, data)
 }

--- a/internal/report/report_debug_operator_templates.go
+++ b/internal/report/report_debug_operator_templates.go
@@ -1,0 +1,32 @@
+package report
+
+const (
+	debugTextDataTemplate = `
+Debug Operator Install Report
+-----------------------------------------
+Report Date: {{ now }}
+OpenShift Version: {{ .OcpVersion }}
+Package Name: {{ .Subscription.Package }}
+Channel: {{ .Subscription.Channel }}
+Catalog Source: {{ .Subscription.CatalogSource }}
+Install Mode: {{ .Subscription.InstallModeType }}
+Timeout: {{ .CsvTimeout }}
+Phase: {{ .Csv.Status.Phase }}
+Message: {{ .Csv.Status.Message }}
+Reason: {{ .Csv.Status.Reason }}
+Conditions: {{ .Csv.Status.Conditions }}
+RequirementStatus: {{ .Csv.Status.RequirementStatus }}
+-----------------------------------------
+`
+	debugJSONDataTemplate = `{"Package Name":"{{ .Subscription.Package }}",
+"Channel":"{{ .Subscription.Channel }}",
+"Catalog Source":"{{ .Subscription.CatalogSource }}",
+"Install Mode":"{{ .Subscription.InstallModeType }}",
+"Timeout":"{{ .CsvTimeout }}",
+{{ if .Csv}}"Phase":"{{ .Csv.Status.Phase }}",
+"Reason":"{{ .Csv.Status.Reason }}",
+"Conditions":"{{ .Csv.Status.Phase }}",
+"CSV Events": "{{ .CsvEvents }}",
+"Pod Events": "{{ .PodEvents }}",
+"Pod Logs": "{{ range .PodLogs }}{PodName: {{ .PodName }}, ContainerName: {{.ContainerName}}, PodLog: {{ .PodLogs }}}{{ end }}"}{{"\n"}}{{ end }}}`
+)


### PR DESCRIPTION
- If there is a timeout a last list operation will try to retrieve the csv that timed out.
- Increased the timeout delay to 2 minutes instead of 1 minute.

Signed-off-by: acmenezes <adcmenezes@gmail.com>

## With this PR GetCompletedCsvWithTimeout now returns the CSV for timed out operators. Other pieces of data such as Pod status, logs and events will also be added to a report for debugging timed out and failed operators.

Fixes #330 #331 


## Changes (required)

- List CSVs for timed out operators
- Changed the timeout delay to 2 minutest instead of 1
- Add debugging report for failed or timed out operators

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests

<!--Please list any external references that might be helpful in understanding your changes.
Feel free to remove this section if unused.-->
## References (optional)