### PR TITLE
ADD --detailed-reports flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ openshift
 *report.json
 .DS_Store
 *report.txt
+*report*
+__debug_bin

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -21,6 +21,7 @@ type checkCommandFlags struct {
 	Packages               []string `json:"packages"`
 	AllInstallModes        bool     `json:"allInstallModes"`
 	ExtraCRDirectory       string   `json:"extraCRDirectory"`
+	DetailedReports        bool     `json:"detailedReports"`
 }
 
 var checkflags checkCommandFlags
@@ -51,6 +52,7 @@ and/or users.`,
 	flags.BoolVar(&checkflags.AllInstallModes, "all-installmodes", false, "when set, all install modes supported by an operator will be tested")
 	flags.StringVar(&checkflags.ExtraCRDirectory, "extra-cr-directory", "",
 		"directory containing the additional Custom Resources to be deployed by the OperandInstall audit. The manifest files should be located in subdirectories named after the packages they are corresponding to.")
+	flags.BoolVar(&checkflags.DetailedReports, "detailed-reports", false, "when set, a debug report will be created with events and logs for the tests being run")
 
 	return cmd
 }
@@ -84,6 +86,7 @@ func runAudits(ctx context.Context, kubeconfig *rest.Config, client operator.Cli
 		capability.WithFilesystem(fs),
 		capability.WithTimeout(time.Minute),
 		capability.WithReportWriter(reportWriter),
+		capability.WithDetailedReports(checkflags.DetailedReports),
 	); err != nil {
 		return err
 	}

--- a/internal/capability/audit.go
+++ b/internal/capability/audit.go
@@ -205,6 +205,13 @@ func withReportWriter(w io.Writer) auditOption {
 	}
 }
 
+func withDetailedReports(detailedReports bool) auditOption {
+	return func(options *auditOptions) error {
+		options.detailedReports = detailedReports
+		return nil
+	}
+}
+
 // New returns a function corresponding to a passed in audit plan
 func newAudit(ctx context.Context, auditType string, opts ...auditOption) (auditFn, auditCleanupFn) {
 	switch strings.ToLower(auditType) {

--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -209,6 +209,7 @@ func RunAudits(ctx context.Context, opts ...auditorOption) error {
 				withCustomResources(audit.customResources),
 				withFilesystem(options.fs),
 				withReportWriter(options.reportWriter),
+				withDetailedReports(options.detailedReports),
 			)
 			if auditFn == nil {
 				logger.Errorf("invalid audit plan specified: %s", function)
@@ -311,6 +312,13 @@ func WithReportWriter(w io.Writer) auditorOption {
 			return fmt.Errorf("report writer cannot be nil")
 		}
 		options.reportWriter = w
+		return nil
+	}
+}
+
+func WithDetailedReports(detailedReports bool) auditorOption {
+	return func(options *auditorOptions) error {
+		options.detailedReports = detailedReports
 		return nil
 	}
 }

--- a/internal/capability/debug.go
+++ b/internal/capability/debug.go
@@ -21,7 +21,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func CollectDebugData(ctx context.Context, options auditOptions) error {
+func CollectDebugData(ctx context.Context, options auditOptions, reportName string) error {
 	c, err := k8sClientset()
 	if err != nil {
 		return fmt.Errorf("couldn't get clientset for operator install debug report: %s", err.Error())
@@ -87,7 +87,7 @@ func CollectDebugData(ctx context.Context, options auditOptions) error {
 		}
 	}
 
-	debugFile, err := options.fs.OpenFile("operator_debug_json_report.json", os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	debugFile, err := options.fs.OpenFile(reportName, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
 	if err != nil {
 		return err
 	}

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -22,7 +22,7 @@ func extractAlmExamples(ctx context.Context, options *auditOptions) error {
 	}
 	almExamples := ""
 	for _, csvVal := range csvList.Items {
-		if strings.HasPrefix(csvVal.ObjectMeta.Name, options.operatorGroupData.Name) {
+		if strings.HasPrefix(csvVal.ObjectMeta.Name, options.subscription.Package) {
 			// map of string interface which consist of ALM examples from the CSVList
 			almExamples = csvVal.ObjectMeta.Annotations["alm-examples"]
 		}
@@ -61,7 +61,7 @@ func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCle
 		}
 
 		if len(options.customResources) == 0 {
-			logger.Debugf("exiting OperandInstall since no ALM_Examples found in CSV")
+			logger.Infow("exiting OperandInstall since no ALM_Examples found in CSV")
 			return nil
 		}
 
@@ -117,6 +117,11 @@ func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCle
 		})
 		if err != nil {
 			return fmt.Errorf("could not generate operand install text report: %v", err)
+		}
+		if options.detailedReports {
+			if err = CollectDebugData(ctx, options, "operand_detailed_report_all.json"); err != nil {
+				return fmt.Errorf("couldn't collect debug data: %s", err)
+			}
 		}
 
 		return nil

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -56,7 +56,7 @@ func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCl
 			if errors.Is(err, operator.TimeoutError) {
 				options.csvTimeout = true
 				options.csv = resultCSV
-				if err = CollectDebugData(ctx, options); err != nil {
+				if err = CollectDebugData(ctx, options, "operator_detailed_report_timeout.json"); err != nil {
 					return fmt.Errorf("couldn't collect debug data: %s", err)
 				}
 
@@ -90,6 +90,11 @@ func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCl
 		})
 		if err != nil {
 			return fmt.Errorf("could not generate operator install text report: %v", err)
+		}
+		if options.detailedReports {
+			if err = CollectDebugData(ctx, options, "operator_detailed_report_all.json"); err != nil {
+				return fmt.Errorf("couldn't collect debug data: %s", err)
+			}
 		}
 
 		return nil

--- a/internal/capability/types.go
+++ b/internal/capability/types.go
@@ -27,6 +27,7 @@ type auditOptions struct {
 	fs                afero.Fs
 	reportWriter      io.Writer
 	csvEvents         *corev1.EventList
+	detailedReports   bool
 }
 
 type auditorOptions struct {
@@ -62,6 +63,9 @@ type auditorOptions struct {
 
 	//  ReportWriter is any io.Writer for the text reports
 	reportWriter io.Writer
+
+	// DetailedReports creates reports containing events and logs
+	detailedReports bool
 }
 
 type (


### PR DESCRIPTION


Signed-off-by: acmenezes <adcmenezes@gmail.com>

<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR

Detailed reports with logs and events are now available by using the --detailed-reports logs. It still creates the timeout reports which may become an option feature as well to be treated on another PR perhaps.

Fixes #338 

## Changes (required)

- Added flag --detailed-reports
- Added new boolean option for flag
- Calling report from each test operator and operand

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [ ] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation if needed
- [ ] I have checked that my changes pass all tests