### PR TITLE
ADD check to force finalizer deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ openshift
 /logs
 
 /std*.json
-*report.json
+*report.jsonq
 .DS_Store
 *report.txt
 *report*

--- a/internal/capability/operand_cleanup.go
+++ b/internal/capability/operand_cleanup.go
@@ -45,6 +45,19 @@ func operandCleanup(ctx context.Context, opts ...auditOption) auditCleanupFn {
 						logger.Debugf("failed operandCleanUp: package: %s error: %s\n", options.subscription.Package, err.Error())
 						return err
 					}
+					// Forcing cleanup of finalizers
+					err := options.client.GetUnstructured(ctx, options.namespace, name, obj)
+					if apierrors.IsNotFound(err) {
+						return nil
+					} else {
+						obj.SetFinalizers([]string{})
+					}
+					err = options.client.GetUnstructured(ctx, options.namespace, name, obj)
+					if apierrors.IsNotFound(err) {
+						return nil
+					} else {
+						return fmt.Errorf("error cleaning up operand after deleting finalizer: %s", err.Error())
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Signed-off-by: acmenezes <adcmenezes@gmail.com>

## Description of PR

Added some logic to check on the existence of finalizers while performing operand cleanups and prevent CR from getting stuck and therefore blocking namespaces from getting deleted.

Fixes #341 

## Changes (required)

- adding check to force finalizer and therefore CR deletion
- and then double check its deletion


<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests

