### PR TITLE
Update the finalizers on the server side

### DIFF
--- a/internal/operator/client.go
+++ b/internal/operator/client.go
@@ -36,6 +36,7 @@ type Client interface {
 	CreateUnstructured(ctx context.Context, obj *unstructured.Unstructured) error
 	GetUnstructured(ctx context.Context, namespace, name string, obj *unstructured.Unstructured) error
 	DeleteUnstructured(ctx context.Context, obj *unstructured.Unstructured) error
+	UpdateUnstructured(ctx context.Context, obj *unstructured.Unstructured) error
 	ListClusterServiceVersions(ctx context.Context, namespace string) (*operatorv1alpha1.ClusterServiceVersionList, error)
 }
 

--- a/internal/operator/unstructured.go
+++ b/internal/operator/unstructured.go
@@ -16,6 +16,10 @@ func (c operatorClient) GetUnstructured(ctx context.Context, namespace, name str
 	return c.Client.Get(ctx, types.NamespacedName{Namespace: namespace, Name: name}, obj)
 }
 
+func (c operatorClient) UpdateUnstructured(ctx context.Context, obj *unstructured.Unstructured) error {
+	return c.Client.Update(ctx, obj)
+}
+
 func (c operatorClient) DeleteUnstructured(ctx context.Context, obj *unstructured.Unstructured) error {
 	return c.Client.Delete(ctx, obj, &client.DeleteOptions{})
 }


### PR DESCRIPTION
<!--Please provide a short description of the contents of your PR with instructions
for testing if necessary-->
## Description of PR
Calling SetFinalizers only sets the local object field. It does not actually update the object on the server. A call to UpdateUnstructured needed to be created in the client struct, and called after updating that field.

<!--All PRs required a linked issue. If there is not an issue for your PR, please
create one with a detailed description of the problem you are solving before you
create a PR, then link that issue below using a #, i.e. "Fixes #101"-->
Fixes #343

Signed-off-by: Brad P. Crochet <brad@redhat.com>


<!--Please list the changes made in your PR to aid your reviewers in understanding the code-->
## Changes (required)
- Update client to have UpdateUnstructured
- Use UpdateUnstructured call

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [X] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation if needed
- [X] I have checked that my changes pass all tests

