### PR TITLE
fixing CleanUp issues with Operand

### DIFF
--- a/internal/capability/auditor.go
+++ b/internal/capability/auditor.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"io/fs"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
 	"time"
 
@@ -159,7 +161,8 @@ func cleanup(ctx context.Context, stack *Stack[auditCleanupFn]) {
 			break
 		}
 		if err := cleaner(ctx); err != nil {
-			logger.Errorf("cleanup failed: %v", err)
+			cleanerName := runtime.FuncForPC(reflect.ValueOf(cleaner).Pointer()).Name()
+			logger.Errorf("CleanerName: %v ---- cleanup failed: %v", cleanerName, err)
 		}
 	}
 	return

--- a/internal/capability/operand_install.go
+++ b/internal/capability/operand_install.go
@@ -53,12 +53,12 @@ func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCle
 		}
 	}
 
+	if err := extractAlmExamples(ctx, &options); err != nil {
+		logger.Errorf("could not get ALM Examples: %v", err)
+	}
+
 	return func(ctx context.Context) error {
 		logger.Debugw("installing operand for operator", "package", options.subscription.Package, "channel", options.subscription.Channel, "installmode", options.subscription.InstallModeType)
-
-		if err := extractAlmExamples(ctx, &options); err != nil {
-			logger.Errorf("could not get ALM Examples: %v", err)
-		}
 
 		if len(options.customResources) == 0 {
 			logger.Infow("exiting OperandInstall since no ALM_Examples found in CSV")
@@ -125,5 +125,5 @@ func operandInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCle
 		}
 
 		return nil
-	}, operandCleanup(ctx, opts...)
+	}, operandCleanup(ctx, options)
 }

--- a/internal/report/report_operand_templates.go
+++ b/internal/report/report_operand_templates.go
@@ -20,5 +20,5 @@ No custom resources
 {{ end }}
 `
 
-	operandJsonReportTemplate = `{{with $dot := .}}{{range $index, $value := .CustomResources }}{"package":"{{ $dot.Subscription.Package }}","Operand Kind":"{{ kind $value }}","Operand Name":"{{ name $value }}","message":"{{ if gt $dot.OperandCount 0 }}created{{ else }}failed{{ end }}"}{{ end }}{{ end }}`
+	operandJsonReportTemplate = `{{with $dot := .}}{{range $index, $value := .CustomResources }}{"package":"{{ $dot.Subscription.Package }}","Operand Kind":"{{ kind $value }}","Operand Name":"{{ name $value }}","message":"{{ if gt $dot.OperandCount 0 }}created{{ else }}failed{{ end }}"}{{ end }}{{ end }}{{"\n"}}`
 )


### PR DESCRIPTION
Signed-off-by: yoza <yoza@redhat.com>

## Description of PR

Fixes #346

## Changes (required)

- Operand Cleanup not cleaning up due to options being recreated and not shared between operator install and operand install

- Error in the get operation for api not found error returning instead of continuing to the other operand to be deleted in operand cleanup function

- Cleanup function doesn't specify its name when logging errors since it is a generic function. Report the actual function name


## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests