### PR TITLE
FIX cleanup issues

### DIFF
--- a/internal/capability/operator_cleanup.go
+++ b/internal/capability/operator_cleanup.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/opdev/opcap/internal/logger"
+	"github.com/opdev/opcap/internal/operator"
 )
 
 func operatorCleanup(ctx context.Context, opts ...auditOption) auditCleanupFn {
@@ -22,39 +23,36 @@ func operatorCleanup(ctx context.Context, opts ...auditOption) auditCleanupFn {
 		// delete subscription
 		if err := options.client.DeleteSubscription(ctx, options.subscription.Name, options.namespace); err != nil {
 			logger.Debugf("Error while deleting Subscription: %w", err)
-			return err
 		}
 
 		// get csv using csvWatcher
 		csv, err := options.client.GetCompletedCsvWithTimeout(ctx, options.namespace, options.csvWaitTime)
-		if err != nil {
-			return err
+		if err != operator.TimeoutError && err != nil {
+			logger.Debugf("Error while deleting CSV: %w", err)
 		}
 
-		// delete cluster service version
-		if err := options.client.DeleteCSV(ctx, csv.ObjectMeta.Name, options.namespace); err != nil {
-			logger.Debugf("Error while deleting ClusterServiceVersion: %w", err)
-			return err
+		if csv != nil {
+			// delete cluster service version
+			if err := options.client.DeleteCSV(ctx, csv.ObjectMeta.Name, options.namespace); err != nil {
+				logger.Debugf("Error while deleting ClusterServiceVersion: %w", err)
+			}
 		}
 
 		// delete operator group
 		if err := options.client.DeleteOperatorGroup(ctx, options.operatorGroupData.Name, options.namespace); err != nil {
 			logger.Debugf("Error while deleting OperatorGroup: %w", err)
-			return err
 		}
 
 		// delete target namespaces
 		for _, ns := range options.operatorGroupData.TargetNamespaces {
 			if err := options.client.DeleteNamespace(ctx, ns); err != nil {
 				logger.Debugf("Error deleting target namespace %s", ns)
-				return err
 			}
 		}
 
 		// delete operator's own namespace
 		if err := options.client.DeleteNamespace(ctx, options.namespace); err != nil {
 			logger.Debugf("Error deleting operator's own namespace %s", options.namespace)
-			return err
 		}
 		return nil
 	}

--- a/internal/capability/operator_install.go
+++ b/internal/capability/operator_install.go
@@ -56,9 +56,9 @@ func operatorInstall(ctx context.Context, opts ...auditOption) (auditFn, auditCl
 			if errors.Is(err, operator.TimeoutError) {
 				options.csvTimeout = true
 				options.csv = resultCSV
-				if err = CollectDebugData(ctx, options, "operator_detailed_report_timeout.json"); err != nil {
-					return fmt.Errorf("couldn't collect debug data: %s", err)
-				}
+				// if err = CollectDebugData(ctx, options, "operator_detailed_report_timeout.json"); err != nil {
+				// 	return fmt.Errorf("couldn't collect debug data: %s", err)
+				// }
 
 			} else {
 				return err


### PR DESCRIPTION
## Description of PR

Fixes a few logic errors on operator cleanup:

Closes #345 
Closes #348 

## Changes (required)
- remove return on cleanup functions and just log
- disable detailed report when the --detailedReports is not present

<!--Please ensure you have completed the following tasks prior to review-->
## Checklist (required)
- [x] I have reviewed and followed the [contribution guidelines](https://github.com/opdev/opcap/blob/main/docs/contribution.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation if needed
- [x] I have checked that my changes pass all tests